### PR TITLE
Skip unnecessary diskSync when loading already-extracted apps

### DIFF
--- a/dashboard/app_manager.js
+++ b/dashboard/app_manager.js
@@ -422,9 +422,7 @@ AppManager.prototype.decompressApp = function (src, dest, options, callback) {
                         return callback(err);
                     } else {
                         this._addApp(app_metadata);
-                        util.diskSync(function () {
-                            callback(null, app_metadata);
-                        });
+                        callback(null, app_metadata);
                     }
                 }.bind(this)
             );
@@ -447,7 +445,9 @@ AppManager.prototype.decompressApp = function (src, dest, options, callback) {
                     return callback(err);
                 }
                 this._addApp(app_metadata);
-                callback(null, app_metadata);
+                util.diskSync(function () {
+                    callback(null, app_metadata);
+                });
             }.bind(this)
         );
     } catch (e) {


### PR DESCRIPTION
decompressApp was calling diskSync (sync + 1s sleep) for every app that was already extracted to the approot, even though no files were written. With 21 user apps this added ~21 seconds to every startup. Moved diskSync to the actual decompression path where files are written to disk and it serves its intended purpose.