### PR TITLE
Add getQueueAndHistory to app SDK and dashboard message handler

### DIFF
--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -600,6 +600,19 @@ define(function (require) {
         );
 
         this._registerHandler(
+            "getQueueAndHistory",
+            function (options, callback) {
+                this.engine.getQueueAndHistory(options || {}, function (err, data) {
+                    if (err) {
+                        callback(err);
+                    } else {
+                        callback(null, data);
+                    }
+                });
+            }.bind(this)
+        );
+
+        this._registerHandler(
             "updateOrder",
             function (data, callback) {
                 this.engine.updateOrder(data, function (err, result) {

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -844,6 +844,21 @@
     };
 
     /**
+     * Get the job queue and history in a single call.
+     *
+     * @method getQueueAndHistory
+     * @param {Object} options
+     * @param {Number} options.start The location in the history results to start
+     * @param {Number} options.count The number of history jobs to return
+     * @param {function} callback
+     * @param {Error} callback.err Error object if there was an error.
+     * @param {Object} callback.data Object with queue and history arrays
+     */
+    FabMoDashboard.prototype.getQueueAndHistory = function (options, callback) {
+        this._call("getQueueAndHistory", options, callback);
+    };
+
+    /**
      * Run the next job in the job queue.
      *
      * @method runNext


### PR DESCRIPTION
The server endpoint and fabmoapi.js method were added in aaa06dcf but the app-facing SDK (fabmo.js) and the dashboard postMessage bridge (dashboard.js) were not updated, causing job_manager.js to fail with "fabmo.getQueueAndHistory is not a function".