### PR TITLE
Add global "K" key shortcut to toggle manual keypad from any app

### DIFF
--- a/dashboard/static/js/events.js
+++ b/dashboard/static/js/events.js
@@ -256,7 +256,22 @@ function handleKeyEvent(key) {
             $frOverride.val(newVal);
             $frOverride.trigger('change');
             break;
-    //console.log('Second Received key: ' + key);
+        case "k":
+            // Debounce to prevent double-firing from multiple event sources
+            var now = Date.now();
+            if (window._lastKeypadToggle && (now - window._lastKeypadToggle) < 500) {
+                break;
+            }
+            window._lastKeypadToggle = now;
+            if ($(".manual-drive-modal").is(":visible")) {
+                $(".manual-drive-exit").trigger("click");
+            } else {
+                $(".manual-drive-enter").trigger("click");
+                // Pull focus out of app iframe so arrow keys work on the keypad
+                window.focus();
+                setTimeout(function () { $("#keypad-modal").focus(); }, 300);
+            }
+            break;
     }
 }
 
@@ -276,10 +291,39 @@ window.addEventListener('message', function(event) {
     handleKeyEvent(event.data.key);
     if (event.data === "refresh-iframes") {
         location.reload();
-    }   
+    }
     //console.log('origin >> ' + event.origin);
 
 });
+
+// Listen for keyup inside the app iframe so global shortcuts work from any app
+function attachIframeKeyListener(iframe) {
+    try {
+        iframe.contentWindow.document.addEventListener('keyup', function (e) {
+            var tag = e.target.tagName.toLowerCase();
+            if (tag === 'input' || tag === 'textarea' || e.target.isContentEditable) {
+                return;
+            }
+            handleKeyEvent(e.key);
+        });
+    } catch (err) {
+        // cross-origin or not yet loaded
+    }
+}
+
+// Watch for the app iframe to appear/change and attach listener on each load
+var _lastIframe = null;
+var observer = new MutationObserver(function () {
+    var iframe = document.getElementById('app-iframe');
+    if (iframe && iframe !== _lastIframe) {
+        _lastIframe = iframe;
+        iframe.addEventListener('load', function () {
+            attachIframeKeyListener(iframe);
+        });
+        attachIframeKeyListener(iframe);
+    }
+});
+observer.observe(document.body, { childList: true, subtree: true });
 
     /********** Document Ready Init **********/
     function docReady () {

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -32,16 +32,8 @@
         this.status = {};
         this.isReady = false;
 
-        // listen for escape key press to quit the engine
-        document.onkeydown = function (e) {
-            // if (e.keyCode === 27) {  ////## removing allows for ESC to be used in manual mode
-            //     console.warn("ESC key pressed - quitting engine.");
-            //     this.stop();
-            if (e.keyCode === 75 && e.ctrlKey) {
-                // } else if (e.keyCode === 75 && e.ctrlKey) {
-                this.manualEnter();
-            }
-        }.bind(this);
+        // Global keyboard shortcuts (like "k" for keypad) are handled by the
+        // parent dashboard via events.js, which listens on the iframe's contentWindow.
 
         function detectswipe(func) {
             swipe_det = new Object();


### PR DESCRIPTION
Apps run in iframes, so keyboard events don't reach the parent dashboard. This adds a MutationObserver in events.js that attaches a keyup listener directly to each app iframe's contentWindow, forwarding key events to the shared handleKeyEvent handler. Pressing "K" toggles the manual keypad open/closed, with input field detection to avoid interfering with typing.

Includes debounce to prevent double-firing and focus management so arrow keys work immediately in the keypad.

Also removes the old Ctrl+K handler from fabmo.js in favor of the centralized approach in events.js.