### PR TITLE
Fix heartbeat false disconnect during feedhold, improve reconnection UX

### DIFF
--- a/g2.js
+++ b/g2.js
@@ -45,6 +45,7 @@ var RECONNECT_READY_TIMEOUT = 5000; // 5s to wait for SYSTEM READY on each attem
 // Heartbeat constants
 var HEARTBEAT_INTERVAL = 5000; // 5s between heartbeat checks
 var HEARTBEAT_TIMEOUT = 3000; // 3s to wait for heartbeat response
+var HEARTBEAT_FEEDHOLD_TIMEOUT = 15000; // 15s timeout during feedhold — more tolerant
 
 var _promiseCounter = 1;
 var intendedClose = false;
@@ -645,6 +646,9 @@ G2.prototype.startHeartbeat = function () {
             if (!this.connected || this._reconnecting) {
                 return;
             }
+            // Use longer timeout during feedhold — G2 is alive but paused
+            var inHold = this.pause_flag || this.status.inFeedHold;
+            var timeout = inHold ? HEARTBEAT_FEEDHOLD_TIMEOUT : HEARTBEAT_TIMEOUT;
             // Skip if we received data recently — G2 is alive
             if (Date.now() - this._lastDataReceived < HEARTBEAT_INTERVAL) {
                 return;
@@ -661,7 +665,7 @@ G2.prototype.startHeartbeat = function () {
                         this._onHeartbeatTimeout();
                     }
                 }.bind(this),
-                HEARTBEAT_TIMEOUT
+                timeout
             );
         }.bind(this),
         HEARTBEAT_INTERVAL
@@ -708,7 +712,12 @@ G2.prototype._onHeartbeatTimeout = function () {
 // Write to the serial port (and log it)
 G2.prototype._write = function (s, callback) {
     if (!this.connected || !this._serialPort || !this._serialPort.isOpen) {
-        log.warn("Attempted write while disconnected: " + String(s).substring(0, 50));
+        log.error("Attempted write while disconnected: " + String(s).substring(0, 50));
+        // Trigger reconnection if not already in progress
+        if (!this._reconnecting) {
+            log.error("Write to disconnected port — initiating reconnection.");
+            this.reconnect();
+        }
         if (callback) {
             setImmediate(callback);
         }

--- a/machine.js
+++ b/machine.js
@@ -310,8 +310,10 @@ function Machine(control_path, callback) {
         function () {
             log.warn("G2 driver reported disconnect — machine entering not_ready state");
             this.status.state = "not_ready";
+            this.info_id += 1;
             this.status.info = {
-                message: "Reconnecting to motion controller...",
+                id: this.info_id,
+                message: "Motion controller disconnected — attempting to reconnect...",
             };
             this.emit("status", this.status);
         }.bind(this)
@@ -725,6 +727,20 @@ Machine.prototype._restoreAfterReconnect = function (callback) {
                 log.info("Reconnect: reapplying machine configuration...");
                 config.machine.update({}, cb);
             },
+            // Step 5: Restore last known position from instance.json
+            function (cb) {
+                log.info("Reconnect: restoring last known position...");
+                if (config.instance) {
+                    config.instance.apply(function (err) {
+                        if (err) {
+                            log.warn("Reconnect: could not restore position: " + err);
+                        }
+                        cb(null);
+                    });
+                } else {
+                    cb(null);
+                }
+            },
         ],
         function (err) {
             if (err) {
@@ -749,10 +765,14 @@ Machine.prototype._restoreAfterReconnect = function (callback) {
                     }
                 }
 
-                // Transition to idle
+                // Transition to idle with reconnection warning
                 log.info("Reconnect: transitioning machine to idle");
                 self.status.state = "idle";
-                delete self.status.info;
+                self.info_id += 1;
+                self.status.info = {
+                    id: self.info_id,
+                    message: "Reconnected to motion controller after brief interruption. Last known position has been restored, but may not be accurate — please rehome your machine before continuing.",
+                };
                 self.setRuntime(null, function () {
                     self.emit("status", self.status);
                     log.info("Machine restored to idle after reconnection");


### PR DESCRIPTION
- Skip heartbeat disconnect trigger during feedhold (use longer 15s timeout instead of 3s so real disconnects are still caught)
- Trigger reconnection from _write() if port is found disconnected (prevents "write while disconnected" lockup on resume/stop)
- Show user-visible modal messages on disconnect and reconnect
- Restore last known position from instance.json after reconnection