### PR TITLE
Improve manual controls responsiveness and prevent runaway motion

### DIFF
--- a/dashboard/static/js/libs/keyboard.js
+++ b/dashboard/static/js/libs/keyboard.js
@@ -143,20 +143,17 @@
     }
 
     // Get keypad icons to light when keyboard arrow keys are used; see note above
-    Keyboard.prototype.start = function (axis, direction) {
+    Keyboard.prototype.start = function (axis, direction, keyCode) {
         // Defensive checks
         if (this.going === true) {
-            console.warn("Keyboard: Already in motion, ignoring start command");
             return;
         }
         if (this.enabled !== true) {
-            console.warn("Keyboard: Not enabled, ignoring start command");
             return;
         }
-    
-        console.log("Keyboard: Starting motion", axis, direction); 
-    
+
         this.move = { axis: axis, dir: direction };
+        this._activeKey = keyCode; // Track which key started motion
         let activeArrowStr =
             "#keyboardArrow_" + axis + (direction === 1 ? "_pos" : "_neg");
         if ($(".fixed-switch input").is(":checked")) {
@@ -209,38 +206,27 @@
         if (this.going || !this.enabled) {
             return;
         }
-        this.nudgeTimer = setTimeout(
-            function () {
-                if (!this.going) {
-                    switch (evt.keyCode) {
-                        case KEY_UP:
-                            this.start("y", 1);
-                            break;
-
-                        case KEY_DOWN:
-                            this.start("y", -1);
-                            break;
-
-                        case KEY_LEFT:
-                            this.start("x", -1);
-                            break;
-
-                        case KEY_RIGHT:
-                            this.start("x", 1);
-                            break;
-
-                        case KEY_PGUP:
-                            this.start("z", 1);
-                            break;
-
-                        case KEY_PGDOWN:
-                            this.start("z", -1);
-                            break;
-                    }
-                }
-            }.bind(this),
-            NUDGE_TIMEOUT
-        );
+        // Start motion immediately — no delay
+        switch (evt.keyCode) {
+            case KEY_UP:
+                this.start("y", 1, evt.keyCode);
+                break;
+            case KEY_DOWN:
+                this.start("y", -1, evt.keyCode);
+                break;
+            case KEY_LEFT:
+                this.start("x", -1, evt.keyCode);
+                break;
+            case KEY_RIGHT:
+                this.start("x", 1, evt.keyCode);
+                break;
+            case KEY_PGUP:
+                this.start("z", 1, evt.keyCode);
+                break;
+            case KEY_PGDOWN:
+                this.start("z", -1, evt.keyCode);
+                break;
+        }
     };
 
     Keyboard.prototype.onMouseLeave = function (evt) {
@@ -254,43 +240,10 @@
         if (evt.keyCode < 27) {
             return;
         } // prevents un-needed kills to shift and ctl release
-        if (this.nudgeTimer) {
-            clearTimeout(this.nudgeTimer);
-            this.nudgeTimer = null;
-            if (!this.enabled) {
-                return;
-            }
-            switch (evt.keyCode) {
-                case KEY_UP:
-                    this.nudge("y", 1);
-                    break;
-
-                case KEY_DOWN:
-                    this.nudge("y", -1);
-                    break;
-
-                case KEY_LEFT:
-                    this.nudge("x", -1);
-                    break;
-
-                case KEY_RIGHT:
-                    this.nudge("x", 1);
-                    break;
-
-                case KEY_PGUP:
-                    this.nudge("z", 1);
-                    break;
-
-                case KEY_PGDOWN:
-                    this.nudge("z", -1);
-                    break;
-                default:
-                    return;
-            }
-        } else {
-            if (this.going || this.enabled) {
-                this.stop();
-            }
+        // Only stop if this is the key that started motion
+        if (this.going && evt.keyCode === this._activeKey) {
+            this._activeKey = null;
+            this.stop();
         }
     };
 

--- a/dashboard/static/js/libs/keypad.js
+++ b/dashboard/static/js/libs/keypad.js
@@ -235,22 +235,23 @@
                 
                 hammer.add(new Hammer.Pan({ threshold: this.pressThreshold }));
 
+                // Hammer tap/press only used for fixed-mode buttons
                 hammer.on("tap", function(evt) {
-                    // FIXED: More thorough exit button detection
                     if (this.isExitButtonEvent(evt)) return;
-                    this.onDriveTap(evt);
+                    // Only handle tap if in fixed mode (optimistic start handles normal mode)
+                    if ($(evt.target).hasClass("drive-button-fixed")) {
+                        this.onDriveTap(evt);
+                    }
                 }.bind(this));
-                
+
                 hammer.on("press", function(evt) {
-                    if (this.isExitButtonEvent(evt)) return;
-                    this.onDrivePress(evt);
+                    // Suppressed — optimistic start handles this via touchstart/mousedown
                 }.bind(this));
-                
+
                 hammer.on("pressup", function(evt) {
-                    if (this.isExitButtonEvent(evt)) return;
-                    this.end();
+                    // Suppressed — handled by touchend/mouseup
                 }.bind(this));
-                
+
                 // FIXED: Only end once when pan starts, don't trigger repeatedly
                 hammer.on("panstart", function(evt) {
                     if (this.isExitButtonEvent(evt)) return;
@@ -258,18 +259,27 @@
                         this.cleanStop();
                     }
                 }.bind(this));
-                
+
+                // OPTIMISTIC START: begin motion immediately on touch/mousedown
+                // Use a per-element data attribute to track press start time
                 $(element).on("touchstart", function(evt) {
                     if (this.isExitButtonEvent(evt)) return;
-                    
-                    this.touchStartTime = Date.now();
-                    this.currentTouchElement = element;
+                    element._pressStart = Date.now();
+                    element._touchHandled = true;
+                    this._optimisticStart(element);
                 }.bind(this));
-                
+
+                $(element).on("mousedown", function(evt) {
+                    if (this.isExitButtonEvent(evt)) return;
+                    if (element._touchHandled) return; // Already handled by touch
+                    element._pressStart = Date.now();
+                    this._optimisticStart(element);
+                }.bind(this));
+
                 $(element).on("touchmove", function(evt) {
                     if (this.isExitButtonEvent(evt)) return;
-                    if (!this.touchStartTime) return;
-                    
+                    if (!element._pressStart) return;
+
                     var touch = evt.originalEvent.touches[0];
                     if (touch) {
                         var elementRect = element.getBoundingClientRect();
@@ -279,27 +289,27 @@
                             touch.clientY >= elementRect.top &&
                             touch.clientY <= elementRect.bottom
                         );
-                        
+
                         if (!isInside) {
+                            element._pressStart = null;
                             this.end();
                         }
                     }
                 }.bind(this));
-                
-                $(element).on("touchend", function(evt) {
+
+                $(element).on("touchend mouseup", function(evt) {
                     if (this.isExitButtonEvent(evt)) return;
-               
-                    // Only call end if we haven't already handled slide-off
-                    if (this.going && !this.slideOffDetected) {
+                    if (!element._pressStart) return;
+                    element._pressStart = null;
+
+                    // Clear touch flag after a tick so mousedown doesn't double-fire
+                    setTimeout(function() { element._touchHandled = false; }, 50);
+
+                    // Only stop if this is the element that started motion
+                    if (this.going && this._activeElement === element && !this.slideOffDetected) {
+                        this._activeElement = null;
                         this.end();
                     }
-
-                setTimeout(() => {
-                    this.touchStartTime = null;
-                    this.currentTouchElement = null;
-                    this.slideOffDetected = false;
-                }, 50);
-                    
                 }.bind(this));
 
                 $(element).on("blur", this.end.bind(this));
@@ -551,15 +561,14 @@
     };
 
     Keypad.prototype.stop = function () {
-        console.log("Keypad: Stop called");
-        
         // Clear the refresh timer immediately
         if (this.interval) {
             clearTimeout(this.interval);
             this.interval = null;
         }
-        
+
         this.going = false;
+        this._endTime = Date.now();
         this.emit("stop", null);
     };
 
@@ -572,6 +581,7 @@
         this.going = false;
         this.enabled = false;
         this.target = null;
+        this._endTime = Date.now(); // Cooldown for cross-axis starts
         
         if (this.interval) {
             clearTimeout(this.interval);
@@ -590,15 +600,14 @@
     };
 
     Keypad.prototype.cleanStop = function () {
-        console.log("Keypad: Clean stop called (slide-off detected)");
-        
         // Immediately set flags to prevent re-entry
         if (!this.going) {
             return; // Already stopped
         }
-        
+
         this.going = false;
         this.enabled = false;
+        this._endTime = Date.now();
         
         // Clear the refresh timer
         if (this.interval) {
@@ -738,6 +747,66 @@
         }
     };
 
+    // Optimistic start: begin continuous motion immediately on contact
+    Keypad.prototype._optimisticStart = function (element) {
+        if (this.guardAgainstExitButton()) return;
+        var e = $(element);
+
+        // In fixed mode, don't optimistically start — let tap handle it
+        if (e.hasClass("drive-button-fixed")) return;
+
+        // Ignore if already moving on a different button
+        if (this.going && this._activeElement !== element) {
+            return;
+        }
+
+        // If already moving on same button, just maintain
+        if (this.going) {
+            return;
+        }
+
+        // Block cross-axis starts while machine is still decelerating from previous stop
+        if (this._endTime && this._activeElement !== element && (Date.now() - this._endTime) < 500) {
+            return;
+        }
+
+        this._activeElement = element;
+        this.setEnabled(true);
+        var axisInfo = this._getAxisFromElement(element);
+        if (axisInfo) {
+            if (axisInfo.second_axis) {
+                this.start(axisInfo.axis, axisInfo.dir, axisInfo.second_axis, axisInfo.second_dir);
+            } else {
+                this.start(axisInfo.axis, axisInfo.dir);
+            }
+            e.addClass("drive-button-active").removeClass("drive-button-inactive");
+        }
+    };
+
+    // Extract axis and direction from a drive button element
+    Keypad.prototype._getAxisFromElement = function (element) {
+        var e = $(element);
+        if (e.hasClass("x_pos") && e.hasClass("y_pos")) return { axis: "x", dir: 1, second_axis: "y", second_dir: 1 };
+        if (e.hasClass("x_neg") && e.hasClass("y_pos")) return { axis: "x", dir: -1, second_axis: "y", second_dir: 1 };
+        if (e.hasClass("x_neg") && e.hasClass("y_neg")) return { axis: "x", dir: -1, second_axis: "y", second_dir: -1 };
+        if (e.hasClass("x_pos") && e.hasClass("y_neg")) return { axis: "x", dir: 1, second_axis: "y", second_dir: -1 };
+        if (e.hasClass("x_pos")) return { axis: "x", dir: 1 };
+        if (e.hasClass("x_neg")) return { axis: "x", dir: -1 };
+        if (e.hasClass("y_pos")) return { axis: "y", dir: 1 };
+        if (e.hasClass("y_neg")) return { axis: "y", dir: -1 };
+        if (e.hasClass("z_pos_fast")) return { axis: "z_fast", dir: 1 };
+        if (e.hasClass("z_pos_slow")) return { axis: "z_slow", dir: 1 };
+        if (e.hasClass("z_neg_fast")) return { axis: "z_fast", dir: -1 };
+        if (e.hasClass("z_neg_slow")) return { axis: "z_slow", dir: -1 };
+        if (e.hasClass("a_pos")) return { axis: "a", dir: 1 };
+        if (e.hasClass("a_neg")) return { axis: "a", dir: -1 };
+        if (e.hasClass("b_pos")) return { axis: "b", dir: 1 };
+        if (e.hasClass("b_neg")) return { axis: "b", dir: -1 };
+        if (e.hasClass("c_pos")) return { axis: "c", dir: 1 };
+        if (e.hasClass("c_neg")) return { axis: "c", dir: -1 };
+        return null;
+    };
+
     Keypad.prototype.onExitTap = function (evt) {
         this.exit();
     };
@@ -753,7 +822,7 @@
         }
         
         // Don't process mouseleave during active touch interactions
-        if (this.touchStartTime || this.currentTouchElement) {
+        if (this.currentTouchElement) {
             return;
         }
         

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -24,7 +24,7 @@ var Q = require("q");
 // Parameters related to filling the queue, motion, etc.
 // These are fussy.
 var T_RENEW = 300;
-var SAFETY_FACTOR = 4.0;
+var SAFETY_FACTOR = 1.5;
 // TODO should be in the ManualDriver instance?!
 var count = 0;
 var RENEW_SEGMENTS = 10;
@@ -204,6 +204,17 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
         return;
     }
 
+    // Reject starts within 500ms of a stop — prevents in-flight messages from causing runaway
+    if (this._awaitingStop) {
+        log.warn("startMotion rejected — awaiting stop confirmation");
+        return;
+    }
+
+    // Reject motion on a different axis while currently moving or stopping
+    if (this.moving && axis !== this.currentAxis) {
+        return;
+    }
+
     // Improved axis switching without debug logging
     if (this.moving) {
         if (axis === this.currentAxis && speed === this.currentSpeed) {
@@ -264,6 +275,7 @@ ManualDriver.prototype.maintainMotion = function () {
 
 // Stop all movement
 ManualDriver.prototype.stopMotion = function () {
+    this._awaitingStop = true;
     this.stop_pending = true;
     this.keep_moving = false;
     if (this.renew_timer) {
@@ -563,6 +575,11 @@ ManualDriver.prototype.nudge = function (axis, speed, distance, second_axis, sec
         log.warn("fixedMove(): Move queue is already full!");
         return;
     }
+    // Reject nudge on a different axis while currently moving
+    if (this.moving && axis.toUpperCase() !== (this.currentAxis || "").toUpperCase()) {
+        log.warn("fixedMove(): Rejected — different axis while in motion.");
+        return;
+    }
     if (second_axis) {
         this.fixedQueue.push({
             axis: axis,
@@ -683,6 +700,7 @@ ManualDriver.prototype._onG2Status = function (status) {
             break;
         case this.driver.STAT_STOP:
             this.stop_pending = false;
+            this._awaitingStop = false;
         // Fall through is intended here, do not add a break
         case this.driver.STAT_END:
         case this.driver.STAT_HOLDING:
@@ -692,6 +710,7 @@ ManualDriver.prototype._onG2Status = function (status) {
             } else {
                 // extra flushes may be coming from here
                 this.stop_pending = false;
+                this._awaitingStop = false; // Clear cooldown — machine confirmed stopped
                 if (!this.driver.pause_hold && this.driver.status.hold === 0) {
                     this.driver._write("%\n"); // flush feed-hold and get stat
                 }

--- a/runtime/manual/index.js
+++ b/runtime/manual/index.js
@@ -24,7 +24,11 @@ ManualRuntime.prototype.toString = function () {
 
 // pass through function for compatibility with opensbp runtime
 // eslint-disable-next-line no-unused-vars
-ManualRuntime.prototype.needsAuth = function (s) {
+ManualRuntime.prototype.needsAuth = function (code) {
+    // Stop and exit should never be gated by auth
+    if (code && (code.cmd === "stop" || code.cmd === "exit" || code.cmd === "quit")) {
+        return false;
+    }
     return true;
 };
 
@@ -109,8 +113,8 @@ ManualRuntime.prototype.executeCode = function (code) {
         case "stopped":
             return;
     }
-    log.info("MANUAL CODE!!");
-    log.info(JSON.stringify(code));
+    log.debug("Manual command: " + code.cmd);
+    log.debug(JSON.stringify(code));
     switch (code.cmd) {
         case "enter":
             this.enter(code.mode, code.hideKeypad || false);


### PR DESCRIPTION
Keypad (mouse/touch):
- Optimistic start: motion begins immediately on contact (no 150ms delay)
- Nudges only fire in fixed mode, not on short clicks in normal mode
- Per-element press tracking prevents cross-button state corruption
- Track active element; ignore other buttons while one is active
- 500ms cross-axis cooldown after any stop (stop/end/cleanStop) prevents in-flight websocket messages from starting motion after stop processed

Keyboard (arrow keys):
- Motion starts immediately on keydown (no 200ms NUDGE_TIMEOUT delay)
- Track which key started motion; only that key's release issues stop
- Prevents runaway when tapping a second axis while holding the first

Server-side (manual driver):
- Reduce SAFETY_FACTOR 4.0 → 1.5 (less buffered distance, faster stop)
- Block startMotion/nudge on different axis while currently moving
- Awaiting-stop flag rejects starts until G2 confirms machine stopped
- Stop/exit/quit bypass auth (no arm/fire delay on safety commands)
- Reduce manual command logging from info to debug level