### PR TITLE
Add soft-limit pre-check and previewer UX upgrades

### DIFF
--- a/dashboard/apps/job_manager.fma/css/style.css
+++ b/dashboard/apps/job_manager.fma/css/style.css
@@ -729,6 +729,62 @@ table {
   z-index: 50;
 }
 
+/* Soft-limit warning: red `!` badge on the play button when the job's
+   bounds exceed the machine envelope. */
+.exceeds-limits-badge {
+  position: absolute;
+  top: 0;
+  right: 30px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #d32f2f;
+  color: #fff;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 26px;
+  text-align: center;
+  border: 2px solid #fff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+  z-index: 60;
+  cursor: help;
+}
+
+.exceeds-limits-tooltip {
+  display: none;
+  position: absolute;
+  right: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: #333;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 1.3;
+  text-align: left;
+  width: max-content;
+  max-width: 360px;
+  white-space: nowrap;
+  z-index: 100;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.exceeds-limits-tooltip::after {
+  content: "";
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 6px solid transparent;
+  border-left-color: #333;
+}
+
+.exceeds-limits-badge:hover .exceeds-limits-tooltip {
+  display: block;
+}
+
 /* Radial progress container */
 .radial_progress {
   margin-top: 5px;

--- a/dashboard/apps/job_manager.fma/index.html
+++ b/dashboard/apps/job_manager.fma/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>Job Manager</title>
 	<link rel="stylesheet" href="../../css/dashboard.css">
-	<link rel="stylesheet" href="./css/style.css">
+	<link rel="stylesheet" href="./css/style.css?v=3">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>

--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -228,7 +228,7 @@ function addQueueEntries(jobs) {
         menu.innerHTML = createQueueMenu(jobs[i]._id);
       // }
     };
-    setFirstCard(); //Add play button and css style for first card
+    setFirstCard(jobs[0]); //Add play button and css style for first card
     isTestJob = jobs[0];
     bindMenuEvents();
   } else {
@@ -279,11 +279,11 @@ function addQueueEntries(jobs) {
 
 }
 
-function setFirstCard() {
+function setFirstCard(job) {
   var firstId = $('.job_item').first().attr('id');
   var el = document.getElementById(firstId);
   var cardActions = document.createElement("div");
-  hideDropDown();  ////## trying here to prevent clickability issue after choosing from 'recent'; update to #48395 
+  hideDropDown();  ////## trying here to prevent clickability issue after choosing from 'recent'; update to #48395
   cardActions.setAttribute("id", "actions");
   el.appendChild(cardActions);
   var actions = document.getElementById("actions");
@@ -293,6 +293,23 @@ function setFirstCard() {
   $('.download').data('id', firstId);
   $('.edit').data('id', firstId);
 
+  // Pre-flight soft-limit warning. analyzeJobBounds runs server-side after
+  // submit and tags `softLimitCheck.exceeds` on out-of-envelope jobs; the
+  // play button gets a red exclamation badge so the user can see the
+  // problem before opening the previewer.
+  if (job && job.softLimitCheck && job.softLimitCheck.exceeds) {
+    var $play = $('.play-button').first();
+    $play.addClass('exceeds-limits');
+    var msg = (job.softLimitCheck.violations || [])
+      .map(function (v) { return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + v.overage.toFixed(2); })
+      .join(', ');
+    // Real DOM badge (instead of ::after) so it can carry its own tooltip —
+    // the play icon's own `title` would otherwise shadow a title set on the
+    // play button.
+    var $badge = $('<span class="exceeds-limits-badge">!<span class="exceeds-limits-tooltip"></span></span>');
+    $badge.find('.exceeds-limits-tooltip').text('Job exceeds soft limits: ' + msg);
+    $play.append($badge);
+  }
 }
 
 
@@ -1129,6 +1146,13 @@ $(document).ready(function() {
     fabmo.on('job_start',function (cmd, data) {
         updateQueue();
         updateHistory();
+    });
+
+    // Server fires `change`/`jobs` after async work mutates a job record
+    // (e.g. analyzeJobBounds saving softLimitCheck post-submit). Without
+    // this listener the queue card never picks up the soft-limit badge.
+    fabmo.on('change', function (topic) {
+        if (topic === 'jobs') updateQueue();
     });
 
     // The queue will update when the status report comes in

--- a/dashboard/apps/previewer.fma/css/style.css
+++ b/dashboard/apps/previewer.fma/css/style.css
@@ -439,6 +439,40 @@ body {
   display: none;
 }
 
+#preview .soft-limit-warning {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 11;
+  background: #fff3cd;
+  color: #5c4400;
+  border: 1px solid #d4a017;
+  border-radius: 4px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-family: sans-serif;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  max-width: 70%;
+  pointer-events: auto;
+}
+
+#preview .soft-limit-warning-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+#preview .soft-limit-warning-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#preview .soft-limit-warning-list li {
+  padding: 1px 0;
+  font-family: monospace;
+}
+
 #preview .dialog {
   display: none;
   position: absolute;
@@ -612,6 +646,93 @@ input[type="range"]::-webkit-slider-runnable-track {
   flex-direction: column;
 }
 
+#preview .operations-panel .ops-setup {
+  border-bottom: 1px solid #444;
+  flex-shrink: 0;
+}
+
+#preview .operations-panel .ops-setup-header {
+  padding: 6px 10px;
+  font-weight: bold;
+  font-size: 12px;
+  background: rgba(49, 51, 102, 0.5);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+#preview .operations-panel .ops-setup-toggle {
+  font-size: 14px;
+  color: #aac;
+  width: 16px;
+  text-align: center;
+}
+
+#preview .operations-panel .ops-setup-body {
+  padding: 6px 10px 8px;
+}
+
+#preview .operations-panel.setup-collapsed .ops-setup-body {
+  display: none;
+}
+
+#preview .operations-panel .ops-setup-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 3px 0;
+  font-size: 11px;
+}
+
+#preview .operations-panel .ops-setup-row label {
+  color: #aac;
+  flex: 1;
+  margin: 0;
+  font-size: 11px;
+}
+
+#preview .operations-panel .ops-setup-row input[type="number"],
+#preview .operations-panel .ops-setup-row select {
+  background: rgba(50, 50, 70, 0.9);
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  padding: 1px 3px;
+  font-size: 11px;
+  width: 60px;
+}
+
+#preview .operations-panel .ops-setup-row .setup-tool-type {
+  width: 52px;
+}
+
+#preview .operations-panel .ops-setup-row .setup-tool-dia,
+#preview .operations-panel .ops-setup-row .setup-tool-angle {
+  width: 50px;
+}
+
+#preview .operations-panel .ops-setup-row .setup-tool-dia-label,
+#preview .operations-panel .ops-setup-row .setup-tool-angle-label {
+  color: #888;
+}
+
+#preview .operations-panel .ops-setup-row .setup-vbit-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+}
+
+#preview .operations-panel .ops-empty {
+  padding: 8px 10px;
+  color: #aab;
+  font-style: italic;
+  font-size: 11px;
+  border-bottom: 1px solid #444;
+}
+
 #preview .operations-panel .ops-header {
   padding: 8px 10px;
   font-weight: bold;
@@ -746,11 +867,23 @@ input[type="range"]::-webkit-slider-runnable-track {
   background: #047a25;
 }
 
-#preview .operations-panel .ops-actions .submit-selected-ops {
+#preview .operations-panel .ops-actions .submit-selected-ops,
+#preview .operations-panel .ops-actions .submit-trimmed {
   background: #313366;
   border-color: #201f2b;
 }
 
-#preview .operations-panel .ops-actions .submit-selected-ops:hover {
+#preview .operations-panel .ops-actions .submit-selected-ops:hover,
+#preview .operations-panel .ops-actions .submit-trimmed:hover {
   background: #3d3f7a;
+}
+
+/* Trim buttons only matter when an in/out selection is set. */
+#preview .operations-panel .ops-actions .run-trimmed,
+#preview .operations-panel .ops-actions .submit-trimmed {
+  display: none;
+}
+#preview.has-selection .operations-panel .ops-actions .run-trimmed,
+#preview.has-selection .operations-panel .ops-actions .submit-trimmed {
+  display: inline-block;
 }

--- a/dashboard/apps/previewer.fma/index.html
+++ b/dashboard/apps/previewer.fma/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/dashboard.css">
-    <link rel="stylesheet" href="./css/style.css?v=22">
+    <link rel="stylesheet" href="./css/style.css?v=23">
   </head>
 
   <body>
@@ -28,14 +28,55 @@
     <div id="preview" style="display: inline-block;">
       <div class="code-line" title="Current File Line"></div>
 
+      <div class="soft-limit-warning" id="soft-limit-warning" style="display: none;">
+        <div class="soft-limit-warning-title">File exceeds machine soft limits</div>
+        <ul class="soft-limit-warning-list"></ul>
+      </div>
+
       <div class="operations-panel" id="operations-panel" style="display: none;">
+        <div class="ops-setup" id="ops-setup">
+          <div class="ops-setup-header" title="Click to collapse/expand">
+            <span>Setup</span>
+            <span class="ops-setup-toggle">−</span>
+          </div>
+          <div class="ops-setup-body">
+            <div class="ops-setup-row">
+              <label>Material thickness</label>
+              <input type="number" class="setup-material-thickness" min="0" step="any"/>
+            </div>
+            <div class="ops-setup-row">
+              <label>Z origin</label>
+              <select class="setup-z-origin">
+                <option value="material">Material Surface</option>
+                <option value="table">Table Surface</option>
+              </select>
+            </div>
+            <div class="ops-setup-row">
+              <label>Default tool</label>
+              <select class="setup-tool-type">
+                <option value="flat">Flat</option>
+                <option value="ball">Ball</option>
+                <option value="vbit">V-Bit</option>
+              </select>
+              <input type="number" class="setup-tool-dia" min="0.01" step="any"/>
+              <span class="setup-tool-dia-label">"</span>
+              <span class="setup-vbit-wrap">
+                <input type="number" class="setup-tool-angle" min="10" max="180" step="1"/>
+                <span class="setup-tool-angle-label">°</span>
+              </span>
+            </div>
+          </div>
+        </div>
         <div class="ops-header">
-          <span>Operations</span>
+          <span class="ops-header-title">Operations</span>
           <span class="ops-toggle-all" title="Select All / None">All</span>
         </div>
         <div class="ops-list" id="ops-list"></div>
+        <div class="ops-empty" id="ops-empty" style="display: none;">No operations parsed in file. Use Setup to set tool defaults, then run the full job.</div>
         <div class="ops-actions">
           <div class="run-now">Run Full Job</div>
+          <button class="run-trimmed" title="Run only the in/out selection">Run Trimmed</button>
+          <button class="submit-trimmed" title="Submit the in/out selection as a new job">Submit Trimmed</button>
           <button class="run-selected-ops" title="Run only the checked operations">Run Selected</button>
           <button class="submit-selected-ops" title="Submit checked operations as a new job">Submit Selected</button>
         </div>
@@ -183,6 +224,16 @@
           <label>Set Material Opacity</label>
           <div class="range-container">
             <input name="material-opacity" type="range" min="0" max="1" step="0.1" value="0.5"/>
+          </div>
+
+          <label>Light Azimuth (rotation around scene)</label>
+          <div class="range-container">
+            <input name="light-azimuth" type="range" min="0" max="360" step="5" value="135"/>
+          </div>
+
+          <label>Light Elevation (above table)</label>
+          <div class="range-container">
+            <input name="light-elevation" type="range" min="5" max="90" step="5" value="25"/>
           </div>
 
           <label>Simulation Resolution (grid points)</label>

--- a/dashboard/apps/previewer.fma/js/app.js
+++ b/dashboard/apps/previewer.fma/js/app.js
@@ -508,6 +508,76 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
   return output.join('\n');
 }
 
+/**
+ * Heuristic SBP-vs-GCode sniff. SBP files have comma-separated commands
+ * (M3,x,y,z / JZ,h / MS,…) and `&var = …` assignments; GCode files use
+ * G/M codes with X/Y/Z words.
+ */
+function looksLikeSBP(content) {
+  if (!content) return false;
+  var sample = content.slice(0, 4096).split('\n');
+  for (var i = 0; i < sample.length; i++) {
+    var line = sample[i].trim();
+    if (!line || line.charAt(0) === "'" || line.charAt(0) === '(') continue;
+    if (/^&\w+\s*=/.test(line)) return true;
+    if (/^[A-Z][A-Z0-9]?\s*,/i.test(line)) return true;   // M3, MS, JZ, CG, …
+    if (/^N?\d*\s*[GM]\d/.test(line)) return false;       // pure GCode line
+  }
+  return false;
+}
+
+/**
+ * Slice a GCode file to a line range and bracket it with safe Z + a rapid
+ * to the first cut start. Used when the loaded job is plain GCode (no SBP
+ * source to expand). Returns the joined string or null if the range is empty.
+ */
+function extractGCodeSelection(fileContent, inLine, outLine, safeZ) {
+  if (!fileContent || !inLine) return null;
+  if (typeof safeZ === 'undefined' || safeZ === null) safeZ = 0;
+
+  var allLines = fileContent.split('\n');
+  if (!outLine) outLine = allLines.length;
+  inLine = Math.max(1, Math.min(inLine, allLines.length));
+  outLine = Math.max(inLine, Math.min(outLine, allLines.length));
+
+  // Carry forward modal context (units, plane, distance mode, coord system,
+  // feed) seen above the selection so the trimmed job behaves the same.
+  var modal = { units: null, distance: null, plane: null, coord: null, feed: null };
+  for (var i = 0; i < inLine - 1 && i < allLines.length; i++) {
+    var u = allLines[i].toUpperCase();
+    var m;
+    if ((m = u.match(/\bG(20|21)\b/)))                modal.units    = 'G' + m[1];
+    if ((m = u.match(/\bG(90|91)(?!\.)\b/)))          modal.distance = 'G' + m[1];
+    if ((m = u.match(/\bG(17|18|19)\b/)))             modal.plane    = 'G' + m[1];
+    if ((m = u.match(/\bG(54|55|56|57|58|59)\b/)))    modal.coord    = 'G' + m[1];
+    if ((m = u.match(/\bF(\d+(?:\.\d+)?)/)))          modal.feed     = 'F' + m[1];
+  }
+
+  // Find first XY in the selection so we can rapid-position before plunging.
+  var startX = null, startY = null;
+  for (var i = inLine - 1; i < outLine && i < allLines.length; i++) {
+    var u = allLines[i].toUpperCase();
+    var mx = u.match(/\bX(-?\d+(?:\.\d+)?)/);
+    var my = u.match(/\bY(-?\d+(?:\.\d+)?)/);
+    if (mx && my) { startX = mx[1]; startY = my[1]; break; }
+  }
+
+  var output = [];
+  output.push('( --- Previewer: In/Out selection ---)');
+  output.push('( In: line ' + inLine + '  Out: line ' + outLine + ')');
+  if (modal.units)    output.push(modal.units);
+  if (modal.distance) output.push(modal.distance);
+  if (modal.plane)    output.push(modal.plane);
+  if (modal.coord)    output.push(modal.coord);
+  output.push('G0 Z' + safeZ);
+  if (startX !== null && startY !== null) output.push('G0 X' + startX + ' Y' + startY);
+  if (modal.feed) output.push(modal.feed);
+  for (var i = inLine - 1; i < outLine && i < allLines.length; i++) output.push(allLines[i]);
+  output.push('G0 Z' + safeZ);
+  output.push('M30');
+  return output.join('\n');
+}
+
 function nowPreviewJob() {
   fabmo.getAppArgs(function(err, args) {
     if (err) console.log(err);
@@ -536,55 +606,54 @@ function nowPreviewJob() {
 
 
   $('.run-now').click(function() {
-    // Check for in/out selection
-    var inOut = viewer ? viewer.getInOutPoints() : null;
-    var hasSelection = inOut && (inOut.inPoint || inOut.outPoint);
-
-    if (hasSelection && originalFileContent) {
-      // Run only the selected portion with tool setup preamble
-      var inLine = inOut.inPoint ? inOut.inPoint.sourceLine : 1;
-      var outLine = inOut.outPoint ? inOut.outPoint.sourceLine : null;
-      var safeZ = (cached_Config && cached_Config.opensbp) ? cached_Config.opensbp.safeZpullUp : 0;
-      var sbpCode = extractSBPSelection(originalFileContent, inLine, outLine, safeZ);
-
-      if (sbpCode) {
-        $('.run-now').hide();
-        fabmo.runSBP(sbpCode, function(err, data) {
-          if (err) {
-            fabmo.notify(err, 'error');
-            $('.run-now').show();
-          }
-        });
-      } else {
-        fabmo.notify('Could not extract selection from file', 'error');
+    $('.run-now').hide();
+    fabmo.runNext(function(err) {
+      if (err) {
+        fabmo.notify(err, 'error');
+        $('.run-now').show();
       }
-    } else {
-      // No selection — run the full job as before
-      $('.run-now').hide();
-      fabmo.runNext(function(err, data) {
-        if (err) {
-          fabmo.notify(err, 'error');
-          $('.run-now').show();
-        }
-      });
-    }
+    });
   });
 
-  // Submit Trimmed Job: delete current job, submit extracted SBP as new job
-  $('.submit-trimmed').click(function() {
+  // Build a trimmed program from the in/out selection. Returns
+  // { code, isSBP, inLine, outLine } or null on failure.
+  function buildTrimmedSelection() {
     var inOut = viewer ? viewer.getInOutPoints() : null;
     if (!inOut || (!inOut.inPoint && !inOut.outPoint) || !originalFileContent) {
-      fabmo.notify('Set In and Out points first', 'error');
-      return;
+      fabmo.notify('Set In and/or Out points first', 'error');
+      return null;
     }
-
     var inLine = inOut.inPoint ? inOut.inPoint.sourceLine : 1;
     var outLine = inOut.outPoint ? inOut.outPoint.sourceLine : null;
-    var sbpCode = extractSBPSelection(originalFileContent, inLine, outLine);
-    if (!sbpCode) {
+    var safeZ = (cached_Config && cached_Config.opensbp) ? cached_Config.opensbp.safeZpullUp : 0;
+    var isSBP = looksLikeSBP(originalFileContent);
+    var code = isSBP
+      ? extractSBPSelection(originalFileContent, inLine, outLine, safeZ)
+      : extractGCodeSelection(originalFileContent, inLine, outLine, safeZ);
+    if (!code) {
       fabmo.notify('Could not extract selection from file', 'error');
-      return;
+      return null;
     }
+    return { code: code, isSBP: isSBP, inLine: inLine, outLine: outLine };
+  }
+
+  // Run the in/out selection in place (no job submission).
+  $('.run-trimmed').click(function() {
+    var sel = buildTrimmedSelection();
+    if (!sel) return;
+    $('.run-trimmed').prop('disabled', true);
+    var done = function(err) {
+      $('.run-trimmed').prop('disabled', false);
+      if (err) fabmo.notify(err, 'error');
+    };
+    if (sel.isSBP) fabmo.runSBP(sel.code, done);
+    else           fabmo.runGCode(sel.code, done);
+  });
+
+  // Submit the in/out selection as a new job (replaces current job in queue).
+  $('.submit-trimmed').click(function() {
+    var sel = buildTrimmedSelection();
+    if (!sel) return;
 
     var currentJobID = cookie.get('job-id');
     if (!currentJobID || currentJobID == -1) {
@@ -594,18 +663,13 @@ function nowPreviewJob() {
 
     $('.submit-trimmed').css('opacity', '0.5').css('pointer-events', 'none');
 
-    // Create a File object with .sbp extension so the job system recognizes it
-    var fileName = 'trimmed_L' + inLine + '-L' + (outLine || 'end') + '.sbp';
-    var file = new File([sbpCode], fileName, { type: 'text/plain' });
+    var ext = sel.isSBP ? '.sbp' : '.nc';
+    var fileName = 'trimmed_L' + sel.inLine + '-L' + (sel.outLine || 'end') + ext;
+    var file = new File([sel.code], fileName, { type: 'text/plain' });
 
-    // Delete the current job, then submit the trimmed one
     fabmo.deleteJob(currentJobID, function(err) {
-      if (err) {
-        console.warn('Could not delete original job:', err);
-        // Continue anyway — still submit the trimmed job
-      }
-
-      fabmo.submitJob(file, {}, function(err, data) {
+      if (err) console.warn('Could not delete original job:', err);
+      fabmo.submitJob(file, {}, function(err) {
         $('.submit-trimmed').css('opacity', '').css('pointer-events', '');
         if (err) {
           fabmo.notify('Failed to submit trimmed job: ' + err, 'error');
@@ -695,6 +759,15 @@ function nowPreviewJob() {
     // Setup grid and table
     viewer.setTable(cached_Config.machine.envelope, cached_Config.driver.g55x, cached_Config.driver.g55y, -1);
 
+    // Provide envelope + active G55 offsets so the previewer can flag files
+    // whose cutting extents would exceed the machine soft-limit envelope.
+    viewer.setSoftLimits(
+      cached_Config.machine.envelope,
+      cached_Config.driver.g55x,
+      cached_Config.driver.g55y,
+      cached_Config.machine.units
+    );
+
     // Load point cloud if leveling is enabled
     viewer.loadPointCloud(cached_Config);
 
@@ -758,9 +831,13 @@ function nowPreviewJob() {
             viewer.setFileMetadata(metadata);
           }
           var operations = parseOperations(content);
-          if (operations.length > 0) {
-            viewer.setOperations(operations);
-          }
+          // Always show the operations panel — Setup controls are useful
+          // even with no parsed operations (and Run Full Job lives there).
+          viewer.setOperations(operations);
+        },
+        error: function() {
+          // File fetch failed — still surface the panel for Setup + Run Full Job
+          viewer.setOperations([]);
         },
         complete: function() {
           // Load gcode after metadata is set

--- a/dashboard/apps/previewer.fma/js/gui.js
+++ b/dashboard/apps/previewer.fma/js/gui.js
@@ -88,6 +88,25 @@ module.exports = function(callbacks) {
   self.hideLoading = function() {show(self.loading, false)}
 
 
+  self.showSoftLimitWarning = function (violations, units) {
+    if (!self.softLimitWarning) return;
+    var $list = $(self.softLimitWarning).find('.soft-limit-warning-list').empty();
+    var u = units || '';
+    for (var i = 0; i < violations.length; i++) {
+      var v = violations[i];
+      var line = v.axis.toUpperCase() + ' exceeds ' + v.direction +
+                 ' by ' + v.overage.toFixed(2) + ' ' + u;
+      $('<li>').text(line).appendTo($list);
+    }
+    show(self.softLimitWarning, true);
+  }
+
+
+  self.hideSoftLimitWarning = function () {
+    if (self.softLimitWarning) show(self.softLimitWarning, false);
+  }
+
+
   self.showErrors = function (errors) {
     var tbody = $('#preview .errors tbody').empty();
 
@@ -143,10 +162,11 @@ module.exports = function(callbacks) {
   self.buttons.help     = get('help', onHelp);
 
   // Dialogs
-  self.loading   = $('#preview .loading')[0];
-  self.errors    = $('#preview .errors')[0];
-  self.help      = $('#preview .help')[0];
-  self.settings  = $('#preview .settings')[0];
+  self.loading           = $('#preview .loading')[0];
+  self.errors            = $('#preview .errors')[0];
+  self.help              = $('#preview .help')[0];
+  self.settings          = $('#preview .settings')[0];
+  self.softLimitWarning  = $('#preview .soft-limit-warning')[0];
   $('#preview .dialog .close').click(onClose);
 
   $('.reset-material').click(function() {

--- a/dashboard/apps/previewer.fma/js/material.js
+++ b/dashboard/apps/previewer.fma/js/material.js
@@ -39,12 +39,19 @@ module.exports = function(scene, update) {
 
   // Stepped column mesh buffers (pre-allocated for performance)
   var posArr = null;       // Float32Array of vertex positions
+  var colorArr = null;     // Float32Array of per-vertex RGB (depth shade)
   var idxArr = null;       // Uint32Array of face indices
   var posAttr = null;      // THREE.BufferAttribute for positions
+  var colorAttr = null;    // THREE.BufferAttribute for vertex colors
   var idxAttr = null;      // THREE.BufferAttribute for indices
   var topVertCount = 0;    // Number of top surface vertices (4 per column)
   var botVertOffset = 0;   // Index offset to bottom vertices in posArr
   var meshMaterial = null;  // Reusable THREE.MeshPhongMaterial
+
+  // Base color of stock (tan); modulated per vertex by depth shading.
+  var baseColor = { r: 0xD2 / 255, g: 0xB4 / 255, b: 0x8C / 255 };
+  // Shade range: deepest cut renders at depthMin, uncut top at 1.0.
+  var depthMin = 0.15;
 
   /**
    * Helper to properly dispose a mesh and track its resources
@@ -154,6 +161,7 @@ module.exports = function(scene, update) {
                  + 2 * (xPoints + yPoints) * 2;                       // outer walls
 
     posArr = new Float32Array(totalVerts * 3);
+    colorArr = new Float32Array(totalVerts * 3);
     idxArr = new Uint32Array(maxFaces * 3);
 
     // Fill bottom vertices (static — never change)
@@ -863,6 +871,10 @@ module.exports = function(scene, update) {
     // Rebuild index buffer (wall topology may have changed)
     var indexCount = buildIndices();
 
+    // Recompute shading — heightmap changed, so per-vertex shading must too.
+    // Cheap (~few ms for typical grids) and avoids stale shading after cuts.
+    computeShading();
+
     // Update GPU buffers
     posAttr.needsUpdate = true;
     idxAttr.needsUpdate = true;
@@ -870,6 +882,58 @@ module.exports = function(scene, update) {
 
     dirtyRegions = [];
     update();
+  };
+
+  /**
+   * Compute per-vertex shade from height. Top of stock renders at full
+   * brightness; deepest cut at depthMin. Linear ramp in between, so each
+   * cut layer reads as a distinct lightness step from above.
+   */
+  function computeShading() {
+    if (!colorArr || !heightMap || !heightMap.heights) return;
+    var xP = heightMap.xPoints;
+    var yP = heightMap.yPoints;
+    var H = heightMap.heights;
+    var bottomZ = materialTop - stockHeight;
+    var range = stockHeight || 1;
+    var span = 1 - depthMin;
+
+    for (var yi = 0; yi < yP; yi++) {
+      for (var xi = 0; xi < xP; xi++) {
+        var h = H[yi * xP + xi];
+        var t = (h - bottomZ) / range;
+        if (t < 0) t = 0; else if (t > 1) t = 1;
+        var shade = depthMin + span * t;
+        var r = baseColor.r * shade;
+        var g = baseColor.g * shade;
+        var b = baseColor.b * shade;
+        var base = (yi * xP + xi) * 4 * 3;
+        for (var v = 0; v < 4; v++) {
+          colorArr[base + v*3]     = r;
+          colorArr[base + v*3 + 1] = g;
+          colorArr[base + v*3 + 2] = b;
+        }
+      }
+    }
+    // Bottom vertices stay at the darkest shade.
+    for (var i = botVertOffset * 3; i < colorArr.length; i += 3) {
+      colorArr[i]     = baseColor.r * depthMin;
+      colorArr[i + 1] = baseColor.g * depthMin;
+      colorArr[i + 2] = baseColor.b * depthMin;
+    }
+    if (colorAttr) colorAttr.needsUpdate = true;
+  }
+
+  /**
+   * Kept for compatibility with the existing azimuth/elevation sliders —
+   * shading is now depth-based, so light direction has no effect. We just
+   * recompute and refresh.
+   */
+  self.setLightDirection = function(azimDeg, elevDeg) {
+    if (geometryCreated) {
+      computeShading();
+      update();
+    }
   };
 
   /**
@@ -894,25 +958,32 @@ module.exports = function(scene, update) {
     var indexCount = buildIndices();
     var t2 = performance.now();
 
+    // Bake depth shading into vertex colors before creating geometry
+    computeShading();
+
     // Create BufferGeometry with pre-allocated typed arrays
     var geometry = new THREE.BufferGeometry();
     posAttr = new THREE.BufferAttribute(posArr, 3);
+    colorAttr = new THREE.BufferAttribute(colorArr, 3);
     idxAttr = new THREE.BufferAttribute(idxArr, 1);
     geometry.setAttribute('position', posAttr);
+    geometry.setAttribute('color', colorAttr);
     geometry.setIndex(idxAttr);
     geometry.setDrawRange(0, indexCount);
     // Skip computeVertexNormals — flatShading computes face normals in the shader
     geometry.computeBoundingSphere();
     activeGeometries.push(geometry);
 
-    // Create material (opaque solid stock with flat shading)
+    // Lit Phong with flatShading — top faces (normal up) catch the top-down
+    // light, walls (sideways) only get ambient, so vertical faces render
+    // visibly darker than horizontal cut floors. Per-vertex colors layer a
+    // depth ramp on top of that.
     if (!meshMaterial) {
       meshMaterial = new THREE.MeshPhongMaterial({
-        color: 0xD2B48C,
-        specular: 0x222222,
-        shininess: 20,
-        side: THREE.DoubleSide,
-        flatShading: true
+        vertexColors: true,
+        flatShading: true,
+        shininess: 0,
+        side: THREE.DoubleSide
       });
       activeMaterials.push(meshMaterial);
     }

--- a/dashboard/apps/previewer.fma/js/path.js
+++ b/dashboard/apps/previewer.fma/js/path.js
@@ -88,6 +88,12 @@ module.exports = function(scene, callbacks) {
 
     geometry.setAttribute('position', buffers[0]);
     geometry.setAttribute('color', buffers[1]);
+    // Cap the raycaster (and renderer) at the actually-used vertices.
+    // The BufferAttribute spans the full pre-allocated 10000-segment slab,
+    // so without this raycaster tests phantom zero-length segments at the
+    // origin that mask hits on the real toolpath nearby.
+    geometry.setDrawRange(0, self.fill * 2);
+    geometry.computeBoundingSphere();
 
     var material = new THREE.LineBasicMaterial({
       vertexColors: THREE.VertexColors,
@@ -552,8 +558,15 @@ module.exports = function(scene, callbacks) {
   }
 
 
-  function setCurrentLine(line) {
-    self.codeLine.text(infoLine + line.toLocaleString());
+  // Displays GCode line plus SBP source line when available, so a mismatch
+  // is visible at a glance during line-mapping debugging. sourceLine is the
+  // 0-based pc (move.sourceLine); we display it 1-based.
+  function setCurrentLine(gcLine, sourceLine) {
+    var text = infoLine + 'GC ' + gcLine.toLocaleString();
+    if (typeof sourceLine === 'number') {
+      text += '  /  SBP ' + (sourceLine + 1).toLocaleString();
+    }
+    self.codeLine.text(text);
   }
   self.setCurrentLine = setCurrentLine;
 
@@ -696,8 +709,8 @@ module.exports = function(scene, callbacks) {
 
     callbacks.position(p);
 
-    setCurrentLine(move.getLine());
-    
+    setCurrentLine(move.getLine(), self.hasSourceLines ? move.sourceLine : undefined);
+
     // Force final material update when simulation completes
     // DO NOT AUTO-RESET - User wants to explore the result!
     if (time >= self.duration && callbacks.materialForceUpdate) {
@@ -717,7 +730,7 @@ module.exports = function(scene, callbacks) {
 
     if (typeof position == 'undefined') {
       self.setMoveTime(self.moves[move].getStartTime());
-      setCurrentLine(line);
+      setCurrentLine(line, self.hasSourceLines ? self.moves[move].sourceLine : undefined);
       return;
     }
 
@@ -738,7 +751,8 @@ module.exports = function(scene, callbacks) {
       self.setMoveTime(time);
     }
 
-    setCurrentLine(line);
+    var srcMove = (minMove !== undefined ? self.moves[minMove] : self.moves[move]);
+    setCurrentLine(line, self.hasSourceLines ? srcMove.sourceLine : undefined);
   }
 
 
@@ -787,7 +801,8 @@ module.exports = function(scene, callbacks) {
     if (!self.loaded) return;
     self.pause();
     self.setMoveTime(self.duration);
-    setCurrentLine(self.lines);
+    var lastMove = self.moves[self.moves.length - 1];
+    setCurrentLine(self.lines, self.hasSourceLines && lastMove ? lastMove.sourceLine : undefined);
   }
 
 

--- a/dashboard/apps/previewer.fma/js/viewer.js
+++ b/dashboard/apps/previewer.fma/js/viewer.js
@@ -69,6 +69,53 @@ module.exports = function(container) {
   }
 
 
+  // Soft-limit envelope and active work offsets, supplied by app.js.
+  // Used to flag files whose cutting extents would exceed the machine envelope.
+  var softLimits = null;
+
+  self.setSoftLimits = function (envelope, g55x, g55y, units) {
+      softLimits = {
+          envelope: envelope,
+          g55: { x: g55x || 0, y: g55y || 0 },
+          units: units || ''
+      };
+  }
+
+
+  // bounds are in work coords; envelope is in machine coords.
+  // machineCoord = workCoord + g55Offset
+  function checkSoftLimits(bounds) {
+      if (!self.gui) return;
+      if (!softLimits || !softLimits.envelope || !bounds) {
+          self.gui.hideSoftLimitWarning && self.gui.hideSoftLimitWarning();
+          return;
+      }
+      var env = softLimits.envelope;
+      var g55 = softLimits.g55;
+      var violations = [];
+      ['x', 'y'].forEach(function (a) {
+          var bMin = bounds.min[a];
+          var bMax = bounds.max[a];
+          if (typeof bMin !== 'number' || typeof bMax !== 'number') return;
+          var machineMin = bMin + g55[a];
+          var machineMax = bMax + g55[a];
+          var envMin = env[a + 'min'];
+          var envMax = env[a + 'max'];
+          if (typeof envMax === 'number' && machineMax > envMax) {
+              violations.push({ axis: a, direction: 'max', overage: machineMax - envMax });
+          }
+          if (typeof envMin === 'number' && machineMin < envMin) {
+              violations.push({ axis: a, direction: 'min', overage: envMin - machineMin });
+          }
+      });
+      if (violations.length) {
+          self.gui.showSoftLimitWarning(violations, softLimits.units);
+      } else {
+          self.gui.hideSoftLimitWarning && self.gui.hideSoftLimitWarning();
+      }
+  }
+
+
   // Called when the canvas or container has resized; scaling to available window.
   self.resize = function(width, height) {
     self.renderer.setSize(width, height);
@@ -179,14 +226,33 @@ module.exports = function(container) {
     self.refresh();
   }
 
+  // Lighting direction (degrees). Cookie-persisted; updated from settings dialog.
+  // Default azimuth is upper-left, elevation is low-raking so micro-relief
+  // (toolpath cuts) casts visible shadows when the scene is viewed top-down.
+  self.lightAzimuth = parseFloat(cookie.get('light-azimuth', 135));
+  self.lightElevation = parseFloat(cookie.get('light-elevation', 25));
+
   function updateLights(bounds) {
+    if (!bounds) bounds = self._lastLightBounds;
+    if (!bounds) return;
+    self._lastLightBounds = bounds;
+
+    var center = util.getCenter(bounds);
     var dims = util.getDims(bounds);
+    var distance = Math.max(dims[0], dims[1], dims[2]) + 10;
 
-    var lx = dims[0] / 2;    //2
-    var ly = dims[1] / 2;
-    var lz = dims[2] / 2;
+    var azim = self.lightAzimuth * Math.PI / 180;
+    var elev = self.lightElevation * Math.PI / 180;
+    var cosE = Math.cos(elev);
+    var dx = distance * cosE * Math.cos(azim);
+    var dy = distance * cosE * Math.sin(azim);
+    var dz = distance * Math.sin(elev);
 
-    self.light2.position.set(lx, ly, lz + 10);
+    self.light2.position.set(center[0] + dx, center[1] + dy, center[2] + dz);
+    if (self.light2.target) {
+      self.light2.target.position.set(center[0], center[1], center[2]);
+      self.light2.target.updateMatrixWorld();
+    }
   }
 
 
@@ -206,6 +272,9 @@ module.exports = function(container) {
       };
     }
 
+    // Check the full-file extents against the machine soft-limit envelope.
+    checkSoftLimits(self.originalBounds);
+
     // Always use original bounds for material, camera, and scene setup
     var sceneBounds = self.originalBounds;
     var size = util.maxDim(sceneBounds);
@@ -215,20 +284,13 @@ module.exports = function(container) {
     self.axes.update(size);
     self.tool.update(size, self.path.position);
 
-    // Initialize material simulation
-    var stockThickness = 0.75; // Default stock thickness
-    var materialTop = 0; // Default: material surface origin (Z=0 is top)
+    // Lift toolpath fractionally so on-surface segments don't z-fight the stock top.
+    if (self.path.obj) self.path.obj.position.z = self.isMetric() ? 0.13 : 0.005;
 
-    // Use VCarve/ShopBot file metadata if available
-    if (self.fileMetadata) {
-      if (self.fileMetadata.materialThickness) {
-        stockThickness = self.fileMetadata.materialThickness;
-      }
-      if (self.fileMetadata.zOrigin && self.fileMetadata.zOrigin.indexOf('table') !== -1) {
-        // Table Surface origin: Z=0 is at the table, material top at Z=stockThickness
-        materialTop = stockThickness;
-      }
-    }
+    // Initialize material simulation — values come from the effective accessors
+    // (Setup overrides win over file metadata; file metadata wins over defaults).
+    var stockThickness = getEffectiveStockThickness();
+    var materialTop = getEffectiveZOrigin() === 'table' ? stockThickness : 0;
 
     // Expand bounds to include material block
     var materialBounds = {
@@ -248,8 +310,9 @@ module.exports = function(container) {
     var materialBottom = materialTop - stockThickness;
     self.table.setZZoff(materialBottom);
 
-    // Tool info is now per-operation; initial material diameter uses first operation or default
-    var toolDia = 0.25;
+    // Tool info is now per-operation; initial material diameter uses the first
+    // operation's tool when available, falling back to the Setup default tool.
+    var toolDia = self.defaultTool.toolDiameter || 0.25;
     if (self.operations && self.operations.length > 0 && self.operations[0].toolInfo) {
       toolDia = self.operations[0].toolInfo.toolDiameter || toolDia;
     }
@@ -293,9 +356,10 @@ module.exports = function(container) {
       }
     }
 
-    // Tag each move with its operation's tool info so the material
-    // simulation can switch bit size/type per operation.
-    if (self.operations && self.path.moves.length) {
+    // Tag each move with tool info so the material simulation can switch
+    // bit size/type per operation; with no parsed ops, every move inherits
+    // the Setup default tool.
+    if (self.path.moves.length) {
       tagMovesWithToolInfo();
     }
 
@@ -323,6 +387,8 @@ module.exports = function(container) {
     }
     var p = self._materialParams;
     self.material.initialize(p.bounds, p.thickness, p.toolDia, p.materialTop);
+    // Sync the current light direction into the freshly-built mesh's hillshade.
+    applyLightDirectionToMaterial();
     self.gui.showLoading('Computing material\u2026');
     self.path.applyAllMaterial(
       function(progress) {
@@ -335,11 +401,23 @@ module.exports = function(container) {
     );
   }
 
-  // Assign toolInfo from operations to each move based on sourceLine ranges
+  // Assign toolInfo from operations to each move based on sourceLine ranges.
+  // Moves with no matching op (or all moves when there are no parsed ops)
+  // fall back to the Setup default tool so the material simulation reflects
+  // user-set bit type/diameter even when the file has no operation metadata.
   function tagMovesWithToolInfo() {
-    if (!self.operations || !self.path.hasSourceLines) return;
-    var ops = self.operations;
-    var moves = self.path.moves;
+    var moves = self.path && self.path.moves;
+    if (!moves || !moves.length) return;
+    var fallback = {
+      toolType: self.defaultTool.toolType,
+      toolDiameter: self.defaultTool.toolDiameter,
+      vbitAngle: self.defaultTool.vbitAngle
+    };
+    var ops = self.operations || [];
+    if (ops.length === 0 || !self.path.hasSourceLines) {
+      for (var i = 0; i < moves.length; i++) moves[i].toolInfo = fallback;
+      return;
+    }
     // Build sorted list of operation ranges (0-based source lines)
     var ranges = [];
     for (var i = 0; i < ops.length; i++) {
@@ -351,12 +429,15 @@ module.exports = function(container) {
     }
     for (var i = 0; i < moves.length; i++) {
       var sl = moves[i].sourceLine;
+      var matched = false;
       for (var r = 0; r < ranges.length; r++) {
         if (sl >= ranges[r].start && sl <= ranges[r].end) {
           moves[i].toolInfo = ranges[r].toolInfo;
+          matched = true;
           break;
         }
       }
+      if (!matched) moves[i].toolInfo = fallback;
     }
   }
 
@@ -422,39 +503,221 @@ module.exports = function(container) {
   // VCarve/ShopBot file metadata (Z origin mode, material thickness)
   self.fileMetadata = null;
 
+  // Session-only Setup overrides (null = follow file metadata / defaults).
+  // Populated when the user edits the Setup section in the operations panel.
+  self.setupOverrides = {
+    materialThickness: null,
+    zOrigin: null
+  };
+
+  // Default tool used by ops with no parsed toolInfo. User-editable in the
+  // Setup section. Per-op edits detach an op from this default; further
+  // changes here only update ops still tracking the default.
+  self.defaultTool = {
+    toolType: 'flat',
+    toolDiameter: 0.25,
+    vbitAngle: 90
+  };
+
+  function getEffectiveStockThickness() {
+    if (self.setupOverrides.materialThickness != null)
+      return self.setupOverrides.materialThickness;
+    if (self.fileMetadata && self.fileMetadata.materialThickness)
+      return self.fileMetadata.materialThickness;
+    return 0.75;
+  }
+
+  function getEffectiveZOrigin() {
+    if (self.setupOverrides.zOrigin != null) return self.setupOverrides.zOrigin;
+    if (self.fileMetadata && self.fileMetadata.zOrigin) {
+      return self.fileMetadata.zOrigin.indexOf('table') !== -1 ? 'table' : 'material';
+    }
+    return 'material';
+  }
+
   self.setFileMetadata = function(metadata) {
     self.fileMetadata = metadata;
     console.log('File metadata set:', JSON.stringify(metadata));
+    // Seed default tool from file-level toolInfo (used when there are 0 ops
+    // or to give Setup section a sensible starting value).
+    if (metadata && metadata.toolInfo) {
+      if (metadata.toolInfo.toolType) self.defaultTool.toolType = metadata.toolInfo.toolType;
+      if (metadata.toolInfo.toolDiameter) self.defaultTool.toolDiameter = metadata.toolInfo.toolDiameter;
+      if (metadata.toolInfo.vbitAngle) self.defaultTool.vbitAngle = metadata.toolInfo.vbitAngle;
+    }
   };
 
   // Operations list parsed from 'New Path blocks
   self.operations = null;
 
-  self.setOperations = function(ops) {
-    self.operations = ops;
-    if (!ops || ops.length === 0) {
-      $('#operations-panel').hide();
-      return;
+  // Helper: rebuild move tags and reload material after a tool override
+  function applyToolChange() {
+    if (self.path && self.path.moves && self.path.moves.length) {
+      tagMovesWithToolInfo();
+      computeMaterial(function() {
+        self.gui.hideLoading();
+        self.refresh();
+      });
     }
+  }
+
+  // Helper: rebuild material after a Setup change (thickness / Z origin /
+  // default tool when there are no ops). Updates material params from the
+  // current effective values; doesn't disturb camera or path geometry.
+  function applySetupChange() {
+    if (!self._materialParams || !self.path || !self.path.bounds) return;
+    var sceneBounds = self.originalBounds || self.path.bounds;
+    var stockThickness = getEffectiveStockThickness();
+    var materialTop = getEffectiveZOrigin() === 'table' ? stockThickness : 0;
+    var materialBottom = materialTop - stockThickness;
+    self._materialParams.thickness = stockThickness;
+    self._materialParams.materialTop = materialTop;
+    self._materialParams.bounds = {
+      min: { x: sceneBounds.min.x - 0.5, y: sceneBounds.min.y - 0.5, z: materialBottom },
+      max: { x: sceneBounds.max.x + 0.5, y: sceneBounds.max.y + 0.5, z: materialTop }
+    };
+    if (!self.operations || self.operations.length === 0) {
+      self._materialParams.toolDia = self.defaultTool.toolDiameter || 0.25;
+    }
+    self.table.setZZoff(materialBottom);
+    if (self.path.moves && self.path.moves.length) {
+      tagMovesWithToolInfo();
+      computeMaterial(function() {
+        self.gui.hideLoading();
+        self.refresh();
+      });
+    }
+  }
+
+  // One-time wiring of the always-visible Setup section. Pre-fills inputs
+  // from current effective values and persists user edits to setupOverrides
+  // / defaultTool, re-rendering the material on each change.
+  var setupSectionInitialized = false;
+  function initSetupSection() {
+    if (setupSectionInitialized) return;
+    setupSectionInitialized = true;
+
+    var $setup = $('#ops-setup');
+    var $thickness = $setup.find('.setup-material-thickness');
+    var $zOrigin = $setup.find('.setup-z-origin');
+    var $toolType = $setup.find('.setup-tool-type');
+    var $toolDia = $setup.find('.setup-tool-dia');
+    var $toolAngle = $setup.find('.setup-tool-angle');
+    var $vbitWrap = $setup.find('.setup-vbit-wrap');
+
+    $thickness.val(getEffectiveStockThickness());
+    $zOrigin.val(getEffectiveZOrigin());
+    $toolType.val(self.defaultTool.toolType);
+    $toolDia.val(self.defaultTool.toolDiameter);
+    $toolAngle.val(self.defaultTool.vbitAngle);
+    $vbitWrap.toggle(self.defaultTool.toolType === 'vbit');
+
+    $setup.find('.ops-setup-header').on('click', function() {
+      var $panel = $('#operations-panel');
+      var collapsed = $panel.toggleClass('setup-collapsed').hasClass('setup-collapsed');
+      $setup.find('.ops-setup-toggle').text(collapsed ? '+' : '−');
+    });
+
+    $thickness.on('change', function() {
+      var v = parseFloat($(this).val());
+      if (!isNaN(v) && v > 0) {
+        self.setupOverrides.materialThickness = v;
+        applySetupChange();
+      }
+    });
+
+    $zOrigin.on('change', function() {
+      self.setupOverrides.zOrigin = $(this).val();
+      applySetupChange();
+    });
+
+    $toolType.on('change', function() {
+      self.defaultTool.toolType = $(this).val();
+      $vbitWrap.toggle(self.defaultTool.toolType === 'vbit');
+      propagateDefaultToolToOps();
+      applySetupChange();
+    });
+
+    $toolDia.on('change', function() {
+      var v = parseFloat($(this).val());
+      if (!isNaN(v) && v > 0) {
+        self.defaultTool.toolDiameter = v;
+        propagateDefaultToolToOps();
+        applySetupChange();
+      }
+    });
+
+    $toolAngle.on('change', function() {
+      var v = parseFloat($(this).val());
+      if (!isNaN(v) && v > 0) {
+        self.defaultTool.vbitAngle = v;
+        propagateDefaultToolToOps();
+        applySetupChange();
+      }
+    });
+  }
+
+  // Update toolInfo on ops still tracking the Setup default, refreshing
+  // their per-op rows. Ops the user has explicitly edited keep their values.
+  function propagateDefaultToolToOps() {
+    if (!self.operations) return;
+    for (var i = 0; i < self.operations.length; i++) {
+      var op = self.operations[i];
+      if (!op._fromDefault) continue;
+      op.toolInfo = {
+        toolType: self.defaultTool.toolType,
+        toolDiameter: self.defaultTool.toolDiameter,
+        vbitAngle: self.defaultTool.vbitAngle
+      };
+      var $row = $('#ops-list .op-entry').eq(i);
+      $row.find('.op-tool-type').val(op.toolInfo.toolType);
+      $row.find('.op-tool-dia').val(op.toolInfo.toolDiameter);
+      $row.find('.op-tool-angle').val(op.toolInfo.vbitAngle);
+      $row.find('.op-angle-wrap').toggle(op.toolInfo.toolType === 'vbit');
+    }
+  }
+
+  self.setOperations = function(ops) {
+    ops = ops || [];
+    self.operations = ops;
+    initSetupSection();
 
     var list = $('#ops-list');
     list.empty();
 
-    // Helper: rebuild move tags and reload material after a tool override
-    function onToolOverride() {
-      if (self.path && self.path.moves.length) {
-        tagMovesWithToolInfo();
-        computeMaterial(function() {
-          self.gui.hideLoading();
-          self.refresh();
-        });
-      }
+    var $panel = $('#operations-panel');
+    var $empty = $('#ops-empty');
+    var $header = $panel.find('.ops-header');
+    var $toggleAll = $panel.find('.ops-toggle-all');
+    var $runSelected = $panel.find('.run-selected-ops');
+    var $submitSelected = $panel.find('.submit-selected-ops');
+
+    // Always show panel + Run Full Job; gate ops-only UI on whether ops exist.
+    $panel.show();
+    $empty.toggle(ops.length === 0);
+    $header.toggle(ops.length > 0);
+    $toggleAll.toggle(ops.length > 0);
+    $runSelected.toggle(ops.length > 0);
+    $submitSelected.toggle(ops.length > 0);
+
+    if (ops.length === 0) {
+      console.log('Operations panel: no operations parsed — showing Setup-only fallback');
+      return;
     }
 
     for (var i = 0; i < ops.length; i++) {
       (function(idx) {
         var op = ops[idx];
-        var ti = op.toolInfo || {};
+        // Inherit default tool when the file didn't supply one.
+        if (!op.toolInfo) {
+          op.toolInfo = {
+            toolType: self.defaultTool.toolType,
+            toolDiameter: self.defaultTool.toolDiameter,
+            vbitAngle: self.defaultTool.vbitAngle
+          };
+          op._fromDefault = true;
+        }
+        var ti = op.toolInfo;
         var entry = $('<div class="op-entry">');
         var topRow = $('<div class="op-top-row">');
         var checkbox = $('<input type="checkbox" checked>').attr('data-op-index', idx);
@@ -484,27 +747,27 @@ module.exports = function(container) {
 
         typeSelect.on('change', function() {
           var type = $(this).val();
-          if (!op.toolInfo) op.toolInfo = {};
           op.toolInfo.toolType = type;
+          op._fromDefault = false;
           angleWrap.toggle(type === 'vbit');
-          onToolOverride();
+          applyToolChange();
         });
 
         diaInput.on('change', function() {
           var dia = parseFloat($(this).val());
           if (dia > 0) {
-            if (!op.toolInfo) op.toolInfo = {};
             op.toolInfo.toolDiameter = dia;
-            onToolOverride();
+            op._fromDefault = false;
+            applyToolChange();
           }
         });
 
         angleInput.on('change', function() {
           var angle = parseFloat($(this).val());
           if (angle > 0) {
-            if (!op.toolInfo) op.toolInfo = {};
             op.toolInfo.vbitAngle = angle;
-            onToolOverride();
+            op._fromDefault = false;
+            applyToolChange();
           }
         });
 
@@ -543,7 +806,7 @@ module.exports = function(container) {
     }
 
     // Toggle all / none
-    $('.ops-toggle-all').off('click').on('click', function() {
+    $toggleAll.off('click').on('click', function() {
       var checkboxes = list.find('input[type="checkbox"]');
       var allChecked = checkboxes.length === checkboxes.filter(':checked').length;
       checkboxes.prop('checked', !allChecked);
@@ -551,7 +814,6 @@ module.exports = function(container) {
       self.reloadForSelectedOperations(self.getSelectedOperationIndices());
     });
 
-    $('#operations-panel').show();
     console.log('Operations panel: ' + ops.length + ' operations');
   };
 
@@ -710,13 +972,13 @@ module.exports = function(container) {
     var moveLine = self.path.moves[moveIdx].getLine();
     self.path.setMoveLinePosition(moveLine, position);
 
-    // Update the Line: display with the original file line number.
-    // SBP:   N = SBP_pc + 20, so 1-based source line = targetN - 19
-    // GCode: N21 = line 1,    so 1-based source line = targetN - 20
-    if (self.path.setCurrentLine && targetN > 0) {
-      var displayLine = self.isSBP ? (targetN - 19) : (targetN - 20);
-      if (displayLine < 1) displayLine = 1;
-      self.path.setCurrentLine(displayLine);
+    // Show both GCode and (when this is an SBP-derived run) SBP source line.
+    if (self.path.setCurrentLine) {
+      var liveMove = self.path.moves[moveIdx];
+      self.path.setCurrentLine(
+        liveMove.getLine(),
+        self.isSBP ? liveMove.sourceLine : undefined
+      );
     }
   }
   
@@ -869,9 +1131,39 @@ module.exports = function(container) {
   };
 
   // Lights
-  self.light2 = new THREE.DirectionalLight(0xffffff, 1);
+  self.light2 = new THREE.DirectionalLight(0xffffff, 0.4);
   self.scene.add(self.light2);
-  self.scene.add(new THREE.AmbientLight(0x808080));
+  // The DirectionalLight target must be in the scene for its world matrix
+  // to update — required so lightAzimuth/lightElevation correctly control
+  // the direction relative to the scene center (not just origin).
+  self.scene.add(self.light2.target);
+  // Dedicated top-down key light. Drives the wall-vs-top contrast on the
+  // material mesh: tops face it, walls don't.
+  var topLight = new THREE.DirectionalLight(0xffffff, 0.9);
+  topLight.position.set(0, 0, 1);
+  self.scene.add(topLight);
+  self.scene.add(new THREE.AmbientLight(0x404040));
+
+  function applyLightDirectionToMaterial() {
+    if (self.material && self.material.setLightDirection) {
+      self.material.setLightDirection(self.lightAzimuth, self.lightElevation);
+    }
+  }
+
+  util.connectSetting('light-azimuth', self.lightAzimuth, function (v) {
+    self.lightAzimuth = parseFloat(v);
+    cookie.set('light-azimuth', self.lightAzimuth);
+    updateLights();
+    applyLightDirectionToMaterial();
+    self.refresh();
+  });
+  util.connectSetting('light-elevation', self.lightElevation, function (v) {
+    self.lightElevation = parseFloat(v);
+    cookie.set('light-elevation', self.lightElevation);
+    updateLights();
+    applyLightDirectionToMaterial();
+    self.refresh();
+  });
 
   // Widgets
   self.dims = new Dimensions(self.scene, self.refresh);
@@ -998,7 +1290,8 @@ module.exports = function(container) {
       var moveIdx = self.path.lastMove;
       var move = self.path.moves[moveIdx];
       if (!move) return;
-      var srcLine = self.path.hasSourceLines ? move.sourceLine : move.getLine();
+      // 1-based: SBP source line = pc+1; GCode line is already 1-based.
+      var srcLine = self.path.hasSourceLines ? (move.sourceLine + 1) : move.getLine();
       self.gui.setInPoint(time, srcLine, moveIdx);
     },
     setOutPoint: function() {
@@ -1007,7 +1300,7 @@ module.exports = function(container) {
       var moveIdx = self.path.lastMove;
       var move = self.path.moves[moveIdx];
       if (!move) return;
-      var srcLine = self.path.hasSourceLines ? move.sourceLine : move.getLine();
+      var srcLine = self.path.hasSourceLines ? (move.sourceLine + 1) : move.getLine();
       self.gui.setOutPoint(time, srcLine, moveIdx);
     },
     stepForward: function() {
@@ -1130,7 +1423,8 @@ module.exports = function(container) {
 
   // --- Toolpath hover/click interaction ---
   var raycaster = new THREE.Raycaster();
-  raycaster.params.Line.threshold = 0.1;  // world-space pick tolerance
+  // Line.threshold is recomputed per pick in findMoveUnderMouse to stay
+  // at ~6 px regardless of zoom; the default value is unused.
   var mouse = new THREE.Vector2();
   var hoveredMove = null;
   var hoverThrottle = null;
@@ -1148,9 +1442,36 @@ module.exports = function(container) {
     if (!self.path.loaded) return null;
     getMouseNDC(event);
     raycaster.setFromCamera(mouse, self.camera);
+    // Scale the line-pick tolerance to a constant screen radius (~6 px),
+    // otherwise zoomed-out views miss most segments and zoomed-in views
+    // grab many at once. For perspective use camera→target distance;
+    // for ortho use the visible frustum height.
+    var pixelRadius = 6;
+    var canvasH = canvas.clientHeight || 1;
+    var worldPerPixel;
+    if (self.camera.isOrthographicCamera) {
+      var visH = (self.camera.top - self.camera.bottom) / (self.camera.zoom || 1);
+      worldPerPixel = visH / canvasH;
+    } else {
+      var dist = self.camera.position.distanceTo(self.controls.target);
+      worldPerPixel = 2 * dist * Math.tan((self.camera.fov * Math.PI / 180) / 2) / canvasH;
+    }
+    // This bundled three.js still consults the legacy `linePrecision` field
+    // for Line.raycast (default 1 world unit), so set it alongside the
+    // modern params.Line.threshold to cover both code paths.
+    var threshold = pixelRadius * worldPerPixel;
+    raycaster.params.Line.threshold = threshold;
+    raycaster.linePrecision = threshold;
     var intersects = raycaster.intersectObject(self.path.obj, true);
     if (intersects.length === 0) return null;
-    return self.path.getMoveAtIntersection(intersects[0].object, intersects[0].index);
+    // Only pick cuts. Rapids draw above the material and visually block
+    // the cut segments below, so including them in hover/click would
+    // surface the wrong move whenever a jog passes over a cut.
+    for (var i = 0; i < intersects.length; i++) {
+      var m = self.path.getMoveAtIntersection(intersects[i].object, intersects[i].index);
+      if (m && !m.rapid) return m;
+    }
+    return null;
   }
 
   canvas.addEventListener('mousemove', function(event) {
@@ -1164,15 +1485,21 @@ module.exports = function(container) {
     var move = findMoveUnderMouse(event);
     if (move) {
       if (hoveredMove !== move) {
+        if (hoveredMove) hoveredMove.setColor(hoveredMove.rapid ? [1,0,0] : [0,1,0]);
         hoveredMove = move;
-        var label = self.path.hasSourceLines
-          ? 'SBP Line ' + move.sourceLine.toLocaleString()
-          : 'Line ' + move.getLine().toLocaleString();
+        move.setColor([1, 1, 1]);  // glow
+        var label = 'GC ' + move.getLine().toLocaleString();
+        if (self.path.hasSourceLines) {
+          label += '  /  SBP ' + (move.sourceLine + 1).toLocaleString();
+        }
         self.path.codeLine.text(label);
         canvas.style.cursor = 'pointer';
+        self.refresh();
       }
     } else if (hoveredMove) {
+      hoveredMove.setColor(hoveredMove.rapid ? [1,0,0] : [0,1,0]);
       hoveredMove = null;
+      self.refresh();
       self.path.codeLine.text('');
       canvas.style.cursor = '';
     }

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -2,8 +2,46 @@ var db = require("../db");
 var util = require("../util");
 var log = require("../log").logger("routes");
 var machine = require("../machine").machine;
+var config = require("../config");
+var bounds = require("../runtime/bounds");
 var fs = require("fs");
 var upload = require("./util").upload;
+
+// Background-compute bounds + soft-limit violation flag for a freshly
+// submitted job and persist them on the job record. Runs after we've
+// already responded to the client so submit latency is unaffected; the
+// dashboard learns of the result via the `change` event from job.save().
+function analyzeJobBounds(job) {
+    if (!job || !job._id) return;
+    db.Job.getFileForJobId(job._id, function (err, file) {
+        if (err || !file || !file.path) {
+            return log.warn("analyzeJobBounds: file lookup failed: " + (err || "no file"));
+        }
+        bounds.computeFileBounds(file.path, function (err, result) {
+            if (err) {
+                log.warn("analyzeJobBounds: " + err.message);
+                return;
+            }
+            var envelope = config.machine.get("envelope") || {};
+            var g55 = {
+                x: config.driver.get("g55x") || 0,
+                y: config.driver.get("g55y") || 0,
+            };
+            var check = bounds.checkAgainstEnvelope(result.bounds, envelope, g55);
+            db.Job.getById(job._id, function (err, fresh) {
+                if (err || !fresh) return;
+                fresh.bounds = result.bounds;
+                fresh.softLimitCheck = check;
+                fresh.save(function () {});
+                log.info(
+                    "Bounds for job " + job._id + ": exceeds=" + check.exceeds +
+                    " (" + result.durationMs + "ms) bounds=" + JSON.stringify(result.bounds) +
+                    " env=" + JSON.stringify(envelope) + " g55=" + JSON.stringify(g55)
+                );
+            });
+        });
+    });
+}
 
 var submitJob = function (req, res, next) {
     upload(req, res, next, function (err, upload) {
@@ -32,6 +70,7 @@ var submitJob = function (req, res, next) {
                 // Create a job and respond
                 db.createJob(file, item, function (err, job) {
                     callback(err, job);
+                    if (!err && job) analyzeJobBounds(job);
                 });
             }, // create_job
             function on_complete(err, jobs) {

--- a/runtime/bounds.js
+++ b/runtime/bounds.js
@@ -1,0 +1,150 @@
+/*
+ * runtime/bounds.js
+ *
+ * Computes the X/Y/Z extents of an uploaded job file without rendering it.
+ * Used at submit time so the dashboard can warn that a job exceeds the
+ * machine soft-limit envelope before the user opens the previewer.
+ *
+ * For .sbp files we run the SBP runtime's simulator to expand commands
+ * (CG arcs, M3/M5 multi-axis, custom cuts) into gcode and then scan that.
+ * For .nc/.gcode files we scan directly.
+ */
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var log = require("../log").logger("bounds");
+
+// Walks gcode lines tracking modal absolute/relative motion and arc cardinal
+// extremes. Returns { min: {x,y,z}, max: {x,y,z} } in the file's coordinate
+// space (machine-coords are derived later via the active G55 offset).
+function scanGCodeBounds(gcode) {
+    var pos = { x: 0, y: 0, z: 0 };
+    var min = { x: Infinity, y: Infinity, z: Infinity };
+    var max = { x: -Infinity, y: -Infinity, z: -Infinity };
+    var seen = false;
+    var absolute = true; // G90
+
+    function update(x, y, z) {
+        if (x < min.x) min.x = x;
+        if (x > max.x) max.x = x;
+        if (y < min.y) min.y = y;
+        if (y > max.y) max.y = y;
+        if (z < min.z) min.z = z;
+        if (z > max.z) max.z = z;
+        seen = true;
+    }
+
+    var lines = gcode.split("\n");
+    for (var i = 0; i < lines.length; i++) {
+        // Strip comments — () inline and ; to end of line.
+        var line = lines[i].toUpperCase().replace(/\([^)]*\)/g, "").replace(/;.*$/, "");
+
+        if (/\bG90(?!\.)\b/.test(line)) absolute = true;
+        if (/\bG91(?!\.)\b/.test(line)) absolute = false;
+
+        // No \b — gcode often packs words together (e.g. `G0X1.5Y2.5`),
+        // and \b doesn't fire between two word characters like `0` and `X`.
+        var mx = line.match(/X(-?\d+(?:\.\d+)?)/);
+        var my = line.match(/Y(-?\d+(?:\.\d+)?)/);
+        var mz = line.match(/Z(-?\d+(?:\.\d+)?)/);
+        if (!mx && !my && !mz) continue;
+
+        var prev = { x: pos.x, y: pos.y, z: pos.z };
+        var nx = mx ? parseFloat(mx[1]) : null;
+        var ny = my ? parseFloat(my[1]) : null;
+        var nz = mz ? parseFloat(mz[1]) : null;
+        pos.x = nx === null ? pos.x : (absolute ? nx : pos.x + nx);
+        pos.y = ny === null ? pos.y : (absolute ? ny : pos.y + ny);
+        pos.z = nz === null ? pos.z : (absolute ? nz : pos.z + nz);
+
+        update(pos.x, pos.y, pos.z);
+
+        // Arc cardinal extremes — bounding box of an arc can extend past
+        // its endpoints when the sweep crosses 0°, 90°, 180°, or 270°
+        // around the arc center.
+        var isArc = /\bG[23]\b/.test(line);
+        if (!isArc) continue;
+        var mi = line.match(/I(-?\d+(?:\.\d+)?)/);
+        var mj = line.match(/J(-?\d+(?:\.\d+)?)/);
+        if (!mi || !mj) continue; // R-form arcs not handled here
+        var clockwise = /\bG2\b/.test(line);
+        var cx = prev.x + parseFloat(mi[1]);
+        var cy = prev.y + parseFloat(mj[1]);
+        var r = Math.hypot(prev.x - cx, prev.y - cy);
+        var a0 = Math.atan2(prev.y - cy, prev.x - cx);
+        var a1 = Math.atan2(pos.y - cy, pos.x - cx);
+        if (clockwise) {
+            if (a1 >= a0) a1 -= 2 * Math.PI;
+        } else {
+            if (a1 <= a0) a1 += 2 * Math.PI;
+        }
+        var lo = Math.min(a0, a1);
+        var hi = Math.max(a0, a1);
+        for (var n = 0; n < 4; n++) {
+            var base = (n * Math.PI) / 2;
+            for (var k = -1; k <= 2; k++) {
+                var a = base + k * 2 * Math.PI;
+                if (a >= lo && a <= hi) {
+                    update(cx + r * Math.cos(a), cy + r * Math.sin(a), pos.z);
+                    break;
+                }
+            }
+        }
+    }
+
+    return seen ? { min: min, max: max } : null;
+}
+
+// Compare bounds (work coords) against the soft-limit envelope (machine
+// coords) using the active G55 offset. Returns
+// { exceeds: bool, violations: [{axis, direction, overage}] }.
+function checkAgainstEnvelope(bounds, envelope, g55) {
+    var violations = [];
+    if (!bounds || !envelope) return { exceeds: false, violations: violations };
+    ["x", "y"].forEach(function (a) {
+        var bMin = bounds.min[a];
+        var bMax = bounds.max[a];
+        if (typeof bMin !== "number" || typeof bMax !== "number") return;
+        var off = (g55 && typeof g55[a] === "number") ? g55[a] : 0;
+        var envMin = envelope[a + "min"];
+        var envMax = envelope[a + "max"];
+        if (typeof envMax === "number" && bMax + off > envMax) {
+            violations.push({ axis: a, direction: "max", overage: bMax + off - envMax });
+        }
+        if (typeof envMin === "number" && bMin + off < envMin) {
+            violations.push({ axis: a, direction: "min", overage: envMin - (bMin + off) });
+        }
+    });
+    return { exceeds: violations.length > 0, violations: violations };
+}
+
+// Compute bounds for a job file (path on disk). Calls back with
+// { bounds, durationMs } or an error.
+function computeFileBounds(filePath, callback) {
+    var t0 = Date.now();
+    fs.readFile(filePath, "utf8", function (err, data) {
+        if (err) return callback(err);
+        var ext = path.extname(filePath).toLowerCase();
+
+        if (ext === ".sbp") {
+            // Lazy require to avoid circular deps at module load time.
+            var SBPRuntime = require("./opensbp/opensbp").SBPRuntime;
+            var runtime = new SBPRuntime();
+            try {
+                runtime.simulateString(data, 0, 0, 0, function (err, gcode) {
+                    if (err) return callback(err);
+                    callback(null, { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 });
+                });
+            } catch (e) {
+                callback(e);
+            }
+        } else {
+            callback(null, { bounds: scanGCodeBounds(data), durationMs: Date.now() - t0 });
+        }
+    });
+}
+
+exports.scanGCodeBounds = scanGCodeBounds;
+exports.checkAgainstEnvelope = checkAgainstEnvelope;
+exports.computeFileBounds = computeFileBounds;


### PR DESCRIPTION
Server: new runtime/bounds.js scans gcode (or simulates SBP first) to compute job extents at submit time; routes/jobs.js stores softLimitCheck on the job record so the dashboard can flag out-of-envelope jobs without opening the previewer.

Job manager: queue card's play button gets a red `!` badge with a custom hover tooltip listing each axis violation; listens for the server `change` event so the badge appears as soon as async bounds analysis finishes.

Previewer: depth-shaded material with darkened vertical faces, lifted toolpath to avoid z-fighting, dual SBP/GCode line numbers, hover glow on picked segments, raycaster threshold scaled to pixel radius (and legacy linePrecision set for bundled three.js r112), rapid-jog skipping in hover/click, and new in/out trim points with Run/Submit Trimmed buttons.