### PR TITLE
Add software limits for manual jog mode

### DIFF
--- a/config/machine_config.js
+++ b/config/machine_config.js
@@ -121,29 +121,32 @@ MachineConfig.prototype.update = function (data, callback, force) {
         }
     }
 
-    //  Define Envelope for G2
+    //  Define Envelope for G2 (G2 stores travel limits in mm internally)
+    var envConv = this._cache.units === "in" ? 25.4 : 1;
     if ("xmin" in this._cache.envelope) {
-        this.machine.driver.command({ xtn: this._cache.envelope["xmin"] });
+        this.machine.driver.command({ xtn: this._cache.envelope["xmin"] * envConv });
     }
     if ("xmax" in this._cache.envelope) {
-        this.machine.driver.command({ xtm: this._cache.envelope["xmax"] });
+        this.machine.driver.command({ xtm: this._cache.envelope["xmax"] * envConv });
     }
     if ("ymin" in this._cache.envelope) {
-        this.machine.driver.command({ ytn: this._cache.envelope["ymin"] });
+        this.machine.driver.command({ ytn: this._cache.envelope["ymin"] * envConv });
     }
     if ("ymax" in this._cache.envelope) {
-        this.machine.driver.command({ ytm: this._cache.envelope["ymax"] });
+        this.machine.driver.command({ ytm: this._cache.envelope["ymax"] * envConv });
     }
     if ("zmin" in this._cache.envelope) {
-        this.machine.driver.command({ ztn: this._cache.envelope["zmin"] });
+        this.machine.driver.command({ ztn: this._cache.envelope["zmin"] * envConv });
     }
     if ("zmax" in this._cache.envelope) {
-        this.machine.driver.command({ ztm: this._cache.envelope["zmax"] });
+        this.machine.driver.command({ ztm: this._cache.envelope["zmax"] * envConv });
     }
-    // Sync limits_on → g2 "lim" parameter
     if ("limits_on" in this._cache) {
         this.machine.driver.command({ lim: this._cache.limits_on ? 1 : 0 });
     }
+    // FabMo handles manual-mode soft limits; ensure G2's are off so they don't
+    // double-fire alarms during jogs.
+    this.machine.driver.command({ sl: 0 });
 
     this.save(function (err, result) {
         if (err) {

--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -1468,6 +1468,21 @@
                   </div>
                 </div>
               </div>
+
+              <div class="large-6 columns">
+                <div class="row collapse">
+                  <label>Enforce Software Limits <span class="tooltip">i
+                    <span class="tooltiptext">
+                      When checked, manual jogging stops at the envelope <br>
+                      boundary in work coordinates. Uncheck to allow <br>
+                      jogging past the envelope (e.g. for setup or <br>
+                      recovery). [default=unchecked] <br>
+                    </span>
+                    </span>
+                  </label>
+                  <input id="machine-softlimits_on" class="machine-input" type="checkbox">
+                </div>
+              </div>
           </fieldset>
 
           <fieldset>

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -537,6 +537,10 @@ $(document).ready(function() {
         }
     });
 
+    $("#machine-softlimits_on").on('change', function() {
+        $(this).attr('value', $(this).is(':checked') ? 'true' : 'false');
+    });
+
     $('.machine-input').change( function() {
             setConfig(this.id, this.value);
     });

--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -335,7 +335,7 @@
             <!-- 'step' for XY and Z is controlled by the fixed distance move size and set in main.js -->
             <div class="axis xaxis">
                 <label class="noselect">
-                X
+                <span class="limit-tag">LIM</span>X
                 </label>
                 <input id="X" autocomplete="off" class="posx pos doselect modal-axi axi" maxlength="6" inputmode="decimal" step="any">
                 <span class="units">&nbsp;</span>
@@ -343,7 +343,7 @@
             </div>
             <div class="axis yaxis">
                 <label class="noselect">
-                Y
+                <span class="limit-tag">LIM</span>Y
                 </label>
                 <input id="Y" autocomplete="off" class="posy pos doselect modal-axi axi" maxlength="6" inputmode="decimal" step="any">
                 <span class="units">&nbsp;</span>
@@ -351,7 +351,7 @@
             </div>
             <div class="axis zaxis">
                 <label class="noselect">
-                Z
+                <span class="limit-tag">LIM</span>Z
                 </label>
                 <input id="Z" autocomplete="off" class="posz pos doselect modal-axi axi" maxlength="6" inputmode="decimal" step="any">
                 <span class="units">&nbsp;</span>
@@ -359,7 +359,7 @@
             </div>
             <div class="axis aaxis">
                 <label class="noselect">
-                A
+                <span class="limit-tag">LIM</span>A
                 </label>
                 <input id="A" autocomplete="off" class="posa pos doselect modal-axi axi" maxlength="6" inputmode="decimal" step="any">
                 <span class="rotunits">o&nbsp;</span>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1724,14 +1724,39 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 }
 
 .manual-drive-message {
-	font-size: 1.5rem;
+	font-size: 1.1rem;
 	font-weight: bold;
 	display: none;
 	color: #d00;
-	height: auto;
 	text-align: center;
-	margin-top: -2px;
-	margin-bottom: 6px;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 10;
+	background: rgba(255, 255, 255, 0.95);
+	padding: 6px 8px;
+	border-bottom: 1px solid #ddd;
+}
+
+/* Soft limit: axis at boundary styling */
+.axis.at-limit input.pos {
+	color: #cc0000 !important;
+}
+.limit-tag {
+	display: none;
+	position: absolute;
+	right: 100%;
+	top: 50%;
+	transform: translateY(-50%);
+	font-size: 14px;
+	font-weight: bold;
+	color: #cc0000;
+	white-space: nowrap;
+	margin-right: 3px;
+}
+.axis.at-limit .limit-tag {
+	display: block;
 }
 
 .keypad-button {
@@ -2206,8 +2231,6 @@ input[type='range']:focus {
 	border-radius: 50%;
   }
 
-
-
 .fa-keypad {
 	line-height: inherit;
 	text-shadow: 1px 1px 4px black;
@@ -2357,6 +2380,7 @@ input[type='range']:focus {
 	color: #313366;
     font-weight: bold;
 	margin-right: 10px;
+	position: relative;
 }
 
 .read-out-container .units, .read-out-container .a-rotunits, .read-out-container .b-rotunits, .read-out-container .c-rotunits {
@@ -3044,8 +3068,9 @@ filter: blur(2px);
 /* Content header area for your existing elements */
 .modal-content-header {
     position: relative;
-    min-height: 0; /* Will expand as needed */
+    min-height: 0;
     padding: 4px 8px;
+    overflow: visible;
 }
 
 /* Title container */

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -135,12 +135,12 @@ var startManualExit = function () {
         // FIXED: Prevent config updates during exit
         window._manualExitInProgress = true;
         
-        // Turn off fixed-distance if it is on
+        // Turn off fixed-distance if on
         $(".drive-button").removeClass("drive-button-fixed");
         $(".slidecontainer").show();
         $(".fixed-input-container").hide();
         $(".fixed-switch input").prop("checked", false);
-        
+
         // Clean up spindle icon
         $("#action-5 img").attr("src", "../img/icon_spindle_off.png");
         $("#action-5").css("background-color", "#ce6402");
@@ -689,12 +689,24 @@ engine.getVersion(function (err, version) {
                         // authenticate.setIsRunning(false);
                     }
                 }
+                // Sync soft-limit DRO indicator from persistent status.softLimit
+                // (driven by server; survives arm/disarm wiping status.info)
+                if (status.state === "manual" && status.softLimit) {
+                    var limAxis = String(status.softLimit.axis).toUpperCase();
+                    var $limAxis = $("#" + limAxis).closest(".axis");
+                    if (!$limAxis.hasClass("at-limit")) {
+                        $(".axis.at-limit").not($limAxis).removeClass("at-limit");
+                        $limAxis.addClass("at-limit");
+                    }
+                } else if ($(".axis.at-limit").length) {
+                    $(".axis.at-limit").removeClass("at-limit");
+                }
                 if (status["info"] && status["info"]["id"] != lastInfoSeen) {
                     lastInfoSeen = status["info"]["id"];
                     if (status.info["message"]) {
                         if (status.state === "manual") {
-                            $("#title_goto").css("visibility", "hidden");
                             $(".manual-drive-message").show();
+                            $("#title_goto").css("visibility", "hidden");
                             $(".manual-drive-message").html(status.info.message);
                             $(".manual-drive-message").addClass("blinking-text");
                             $("#action-1").css("visibility", "hidden");
@@ -702,7 +714,6 @@ engine.getVersion(function (err, version) {
                             $("#action-3").css("visibility", "hidden");
                             $("#action-4").css("visibility", "hidden");
                             $("#action-5").css("visibility", "hidden");
-                            // Use "display: none" to hide and remove space
                             $(".title-container").css("display", "none");
                         } else if (status.info["timer"] && status.info["timer"] <= TIMER_DISPLAY_CUTOFF) {
                             keypad.setEnabled(false);
@@ -1314,6 +1325,7 @@ $(".manual-drive-exit").on("click", function (evt) {
     $(".manual-drive-message").html("");
     $(".manual-drive-message").hide();
     $(".manual-drive-message").removeClass("blinking-text");
+    $(".axis.at-limit").removeClass("at-limit");
 
     startManualExit()
         .then(() => {

--- a/g2.js
+++ b/g2.js
@@ -404,6 +404,8 @@ G2.prototype.connect = function (path, callback) {
             this._write(
                 "\x04\n",
                 function () {
+                    // Clear any leftover alarm state (e.g. soft limit from previous session)
+                    this.command({ clear: null });
                     this.requestStatusReport(
                         function () {
                             this.startHeartbeat();

--- a/machine.js
+++ b/machine.js
@@ -140,6 +140,7 @@ function Machine(control_path, callback) {
         targetHit: false,
         lastState: null,
         clientDisconnected: false,
+        softLimit: null,
     };
 
     this.fireButtonDebounce = false;
@@ -623,13 +624,15 @@ Machine.prototype.restoreDriverState = function (callback) {
                                         // (machine config apply would trigger unit conversion again, so we do it manually)
                                         var envelope = config.machine._cache.envelope;
                                         if (envelope) {
+                                            // G2 stores travel limits in mm internally
+                                            var eConv = config.machine._cache.units === "in" ? 25.4 : 1;
                                             var envCmds = {};
-                                            if ("xmin" in envelope) envCmds.xtn = envelope.xmin;
-                                            if ("xmax" in envelope) envCmds.xtm = envelope.xmax;
-                                            if ("ymin" in envelope) envCmds.ytn = envelope.ymin;
-                                            if ("ymax" in envelope) envCmds.ytm = envelope.ymax;
-                                            if ("zmin" in envelope) envCmds.ztn = envelope.zmin;
-                                            if ("zmax" in envelope) envCmds.ztm = envelope.zmax;
+                                            if ("xmin" in envelope) envCmds.xtn = envelope.xmin * eConv;
+                                            if ("xmax" in envelope) envCmds.xtm = envelope.xmax * eConv;
+                                            if ("ymin" in envelope) envCmds.ytn = envelope.ymin * eConv;
+                                            if ("ymax" in envelope) envCmds.ytm = envelope.ymax * eConv;
+                                            if ("zmin" in envelope) envCmds.ztn = envelope.zmin * eConv;
+                                            if ("zmax" in envelope) envCmds.ztm = envelope.zmax * eConv;
                                             for (var ek in envCmds) {
                                                 var cmd = {};
                                                 cmd[ek] = envCmds[ek];

--- a/profiles/default/config/machine.json
+++ b/profiles/default/config/machine.json
@@ -9,6 +9,7 @@
 	"ap_input" : 0,
 	"ap_time" : 8,
     "limits_on" : true,
+    "softlimits_on" : false,
     "di1ac": "none",
     "di2ac": "none",
     "di3ac": "none",

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -60,12 +60,22 @@ function ManualDriver(drv, st, mode) {
     this.exit_pending = false;
     this.stop_pending = false;
 
+    // Planned position: the endpoint of all queued incremental moves.
+    // Used to prevent queuing past the boundary (overshoot prevention).
+    // Resynced from status when status overtakes planned (moves consumed).
+    this.plannedPos = {};
+
     // The default mode is "normal" (feed the queue with constant movement along a vector)
     if (mode === "raw") {
         this.mode = "raw";
     } else {
         this.mode = "normal";
     }
+
+    this._atBoundary = false;
+    // True once LIM has been signaled (or suppressed) for the current press.
+    // Reset on stopMotion so the next press into a known boundary can fire LIM.
+    this._limShownThisAttempt = false;
 
     // Current trajectory
     this.current_axis = null;
@@ -203,12 +213,30 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
     var second_dir = second_speed < 0 ? -1.0 : 1.0;
     speed = Math.abs(speed);
     this.gotoModeHold = false;
-    
+
     if (this.mode != "normal") {
         throw new Error("Cannot start movement in " + this.mode + " mode.");
     }
-    
+
     if (this.stop_pending) {
+        return;
+    }
+
+    // If already at boundary in the same direction, short-circuit: keep the
+    // alive flag set and return without writing to G2.
+    // Emit LIM only on the first short-circuit since the last stopMotion —
+    // i.e. user is deliberately pushing into a known limit, not just arriving.
+    if (this._atBoundary &&
+        axis === this.currentAxis &&
+        dir === this.currentDirection) {
+        if (!this._limShownThisAttempt) {
+            this._limShownThisAttempt = true;
+            this.emit("softLimit", {
+                axis: this.currentAxis.toUpperCase(),
+                dir: this.currentDirection < 0 ? "minimum" : "maximum",
+            });
+        }
+        this.keep_moving = true;
         return;
     }
 
@@ -219,11 +247,18 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
             return;
         } else {
             // Smooth axis transitions
+            if (this._atBoundary) {
+                this._atBoundary = false;
+                this._limShownThisAttempt = false;
+                this.emit("softLimitClear");
+            }
+            this.plannedPos = {};
+
             if (this.renew_timer) {
                 clearTimeout(this.renew_timer);
                 this.renew_timer = null;
             }
-            
+
             this.currentAxis = axis;
             this.currentSpeed = speed;
             this.currentDirection = dir;
@@ -243,6 +278,11 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
         }
     } else {
         // Fresh motion start
+        if (this._atBoundary) {
+            this._atBoundary = false;
+            this.emit("softLimitClear");
+        }
+        this.plannedPos = {};
         if (second_axis) {
             this.second_axis = second_axis;
             this.second_currentDirection = second_dir;
@@ -250,7 +290,7 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
             this.second_axis = null;
             this.second_currentDirection = null;
         }
-        
+
         this.currentAxis = axis;
         this.currentSpeed = speed;
         this.currentDirection = dir;
@@ -274,6 +314,13 @@ ManualDriver.prototype.maintainMotion = function () {
 ManualDriver.prototype.stopMotion = function () {
     this.stop_pending = true;
     this.keep_moving = false;
+    this.plannedPos = {};
+    // Don't reset _atBoundary here — releasing the button at a limit doesn't
+    // change the fact that we're at the limit. It's cleared by startMotion
+    // when motion in a different direction begins.
+    // Reset _limShownThisAttempt so the next press into a known boundary
+    // re-fires the LIM indicator.
+    this._limShownThisAttempt = false;
     if (this.renew_timer) {
         clearTimeout(this.renew_timer);
     }
@@ -594,6 +641,34 @@ ManualDriver.prototype.isMoving = function () {
     return this.moving;
 };
 
+// Return the available margin (distance to boundary) for a given axis and direction.
+// Reads envelope (table coords) and G55 offset live so it always reflects the
+// current zero — no stale cached bounds if the user re-zeroes mid-session.
+//   axis - Axis letter (e.g. "x", "X")
+//   direction - Sign of motion: -1 or +1
+//   pos - (optional) work position to check from; defaults to status position
+ManualDriver.prototype._getMargin = function (axis, direction, pos) {
+    var envelope = config.machine._cache.envelope;
+    if (!envelope) return Infinity;
+    var axisLower = axis.toLowerCase();
+    var currentPos = (pos !== undefined) ? pos : this.driver.status["pos" + axisLower];
+    if (currentPos === undefined) return Infinity;
+
+    var offset = config.driver.get("g55" + axisLower) || 0;
+    if (envelope[axisLower + "min"] === undefined || envelope[axisLower + "max"] === undefined) return Infinity;
+    // Envelope is in table (G53) coords; convert to work coords by subtracting g55 offset.
+    var workMin = envelope[axisLower + "min"] - offset;
+    var workMax = envelope[axisLower + "max"] - offset;
+
+    var margin;
+    if (direction < 0) {
+        margin = currentPos - workMin;
+    } else {
+        margin = workMax - currentPos;
+    }
+    return Math.max(margin, 0);
+};
+
 // Internal function called to "pump" moves into the queue
 // This function is called periodically until a == stop is requested ==,
 // or the users intent to continue moving evaporates ////##??.
@@ -607,17 +682,96 @@ ManualDriver.prototype._renewMoves = function (reason) {
                 this.keep_moving = false;
                 return;
             }
-            
+
             if (reason === "start") {
                 this.moving = true;
             }
-            
+
             var segment = this.currentDirection * (this.renewDistance / RENEW_SEGMENTS);
             var second_segment = this.second_currentDirection * (this.renewDistance / RENEW_SEGMENTS);
-            var moves = [];
-            
+            var segmentCount = RENEW_SEGMENTS;
+
+            // --- Planned-position tracking for overshoot prevention ---
+            // plannedPos tracks the endpoint of all queued incremental moves.
+            // We clip against plannedPos (not status) so moves already in the
+            // G2 planner buffer are accounted for.
+            // Initialize once from status, then only accumulate — never resync
+            // from status during motion (G2 can report transient position spikes
+            // during acceleration that would corrupt the margin calculation).
+            // Explicit resets in startMotion/stopMotion handle re-initialization.
+            var axisLower = this.currentAxis.toLowerCase();
+            if (this.plannedPos[axisLower] === undefined) {
+                var statusPos = this.driver.status["pos" + axisLower];
+                this.plannedPos[axisLower] = (statusPos !== undefined && statusPos !== null) ? statusPos : 0;
+            }
+
             if (this.second_axis) {
-                for (var i = 0; i < RENEW_SEGMENTS; i++) {
+                var secondLower = this.second_axis.toLowerCase();
+                if (this.plannedPos[secondLower] === undefined) {
+                    var secondStatus = this.driver.status["pos" + secondLower];
+                    this.plannedPos[secondLower] = (secondStatus !== undefined && secondStatus !== null) ? secondStatus : 0;
+                }
+            }
+
+            // Clip batch to work-coordinate bounds using plannedPos.
+            if (config.machine._cache.envelope && config.machine._cache.softlimits_on) {
+                var batchDistance = Math.abs(segment) * segmentCount;
+                var margin = this._getMargin(this.currentAxis, this.currentDirection, this.plannedPos[axisLower]);
+
+                if (this.second_axis) {
+                    var secondMargin = this._getMargin(this.second_axis, this.second_currentDirection, this.plannedPos[secondLower]);
+                    var secondBatch = Math.abs(second_segment) * segmentCount;
+                    var scale = 1;
+                    if (batchDistance > 0 && margin < batchDistance) {
+                        scale = Math.min(scale, margin / batchDistance);
+                    }
+                    if (secondBatch > 0 && secondMargin < secondBatch) {
+                        scale = Math.min(scale, secondMargin / secondBatch);
+                    }
+                    if (scale <= 0) {
+                        margin = 0;
+                    } else if (scale < 1) {
+                        segment = segment * scale;
+                        second_segment = second_segment * scale;
+                    }
+                } else {
+                    if (batchDistance > 0 && margin < batchDistance && margin > 0) {
+                        segment = this.currentDirection * (margin / segmentCount);
+                    }
+                }
+
+                if (margin <= 0) {
+                    // Planned endpoint has reached the boundary — stop queuing
+                    // new moves, but keep the renew timer alive.
+                    // Only emit the softLimit indicator when the actual machine
+                    // position (status) is within 0.5 units of the boundary,
+                    // not when the queued endpoint reaches it (which can be
+                    // many inches ahead due to planner buffering).
+                    var statusMargin = this._getMargin(this.currentAxis, this.currentDirection);
+                    if (!this._atBoundary && statusMargin <= 0.5) {
+                        // First arrival at the boundary in this press session —
+                        // silent stop. LIM only shows if the user releases and
+                        // pushes again (handled in startMotion's short-circuit).
+                        this._atBoundary = true;
+                        this._limShownThisAttempt = true;
+                        var axisName = this.currentAxis.toUpperCase();
+                        var dir = this.currentDirection < 0 ? "minimum" : "maximum";
+                        log.info("Soft limit reached (silent): axis=" + axisName + " dir=" + dir);
+                    }
+                    this.renew_timer = setTimeout(
+                        function () {
+                            this._renewMoves("timeout");
+                        }.bind(this),
+                        T_RENEW
+                    );
+                    return;
+                }
+            }
+
+            var moves = [];
+
+            if (this.second_axis) {
+                for (var i = 0; i < segmentCount; i++) {
                     var move =
                         "G1" +
                         this.currentAxis +
@@ -628,14 +782,21 @@ ManualDriver.prototype._renewMoves = function (reason) {
                     moves.push(move);
                 }
             } else {
-                for (var i = 0; i < RENEW_SEGMENTS; i++) {
+                for (var i = 0; i < segmentCount; i++) {
                     var move = "G1" + this.currentAxis + segment.toFixed(4) + "\n";
                     moves.push(move);
                 }
             }
-            
+
             this.stream.write(moves.join(""));
             this.driver.prime();
+
+            // Advance planned position by queued batch
+            this.plannedPos[axisLower] += segment * segmentCount;
+            if (this.second_axis) {
+                this.plannedPos[secondLower] += second_segment * segmentCount;
+            }
+
             this.renew_timer = setTimeout(
                 function () {
                     this._renewMoves("timeout");

--- a/runtime/manual/index.js
+++ b/runtime/manual/index.js
@@ -80,6 +80,26 @@ ManualRuntime.prototype.enter = function (mode, hideKeypad) {
 
     // Create a helper that is used to do the pumping of commands.
     this.helper = new ManualDriver(this.driver, this.stream, mode);
+
+    // Soft-limit indicator state (persistent on machine.status, survives arm/disarm)
+    this.helper.on(
+        "softLimit",
+        function (er) {
+            log.info("Soft limit reached: " + er.axis + " " + er.dir);
+            this.machine.status.softLimit = { axis: er.axis, dir: er.dir };
+            this.machine.emit("status", this.machine.status);
+        }.bind(this)
+    );
+
+    this.helper.on(
+        "softLimitClear",
+        function () {
+            log.info("Soft limit cleared");
+            this.machine.status.softLimit = null;
+            this.machine.emit("status", this.machine.status);
+        }.bind(this)
+    );
+
     // TODO: Determine if this is needed it currently does nothing
     this.helper.enter().then(
         function () {
@@ -124,6 +144,7 @@ ManualRuntime.prototype.executeCode = function (code) {
             switch (code.cmd) {
                 case "exit":
                     log.debug("---- MANUAL DRIVE EXIT ----");
+                    this.machine.status.softLimit = null;
                     this.helper.exit();
                     break;
 


### PR DESCRIPTION
Adds an opt-in soft-limit feature that clips manual jogs at the machine envelope expressed in work coordinates (envelope - G55 offset).  Toggled via Configuration → Machine → Enforce Software Limits.  G2's own soft limit (sl) is held at 0; clipping happens FabMo-side before moves reach the planner, so jogs stop cleanly at the boundary without firing G2 alarms.  File-run limits remain unaddressed (future work).

DRO LIM indicator only appears when the user deliberately pushes against a known limit — first arrival during a jog is silent.  Indicator state lives on machine.status.softLimit so it persists across arm/disarm cycles.  Margins are read live from envelope and g55 offsets, so re-zeroing mid-session takes effect immediately.

Other carry-along fixes:
- Convert envelope in→mm when sending to G2 (xtn/xtm/...) since G2 stores travel limits in mm internally.
- Clear leftover alarm state on G2 connect.