### PR TITLE
Add per-axis soft-limit override prompt in manual jog

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -331,6 +331,21 @@
 
     <div class="manual-drive-container">
         <div class="read-out-container">
+          <!-- Inline prompt for soft-limit override (lives inside the readout
+               container so it covers only the DRO area, not the jog buttons,
+               and is inside the keypad modal so click-to-confirm doesn't trip
+               click-outside dismissal). -->
+          <div class="manual-drive-prompt" id="soft-limit-prompt" style="display: none;">
+              <div class="prompt-message">
+                  Allow temporary soft-limit override on the
+                  <span class="prompt-axis"></span> axis?
+                  <span class="prompt-note">Override clears when you close the keypad.</span>
+              </div>
+              <div class="prompt-actions">
+                  <button type="button" class="prompt-allow">Allow</button>
+                  <button type="button" class="prompt-cancel">Cancel</button>
+              </div>
+          </div>
           <div class="read-out-wrapper">
             <!-- 'step' for XY and Z is controlled by the fixed distance move size and set in main.js -->
             <div class="axis xaxis">

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1739,6 +1739,75 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 	border-bottom: 1px solid #ddd;
 }
 
+/* Soft-limit override prompt — overlays the readout (DRO) area only, so
+   accidental clicks while it appears can't hit the jog buttons. Lives
+   inside the keypad modal so confirming/dismissing doesn't fire the
+   click-outside-closes handler. */
+.manual-drive-prompt {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 100;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	background: rgba(255, 255, 255, 0.97);
+	border: 2px solid #d32f2f;
+	border-radius: 6px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+	padding: 16px 18px;
+	color: #222;
+	text-align: center;
+	box-sizing: border-box;
+}
+.manual-drive-prompt .prompt-message {
+	font-size: 1rem;
+	line-height: 1.4;
+	margin-bottom: 14px;
+}
+.manual-drive-prompt .prompt-axis {
+	font-weight: bold;
+	color: #d32f2f;
+}
+.manual-drive-prompt .prompt-note {
+	display: block;
+	font-size: 0.85rem;
+	color: #666;
+	margin-top: 6px;
+	font-weight: normal;
+}
+.manual-drive-prompt .prompt-actions {
+	display: flex;
+	justify-content: center;
+	gap: 12px;
+}
+.manual-drive-prompt button {
+	min-width: 90px;
+	padding: 8px 16px;
+	font-size: 0.95rem;
+	font-weight: bold;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+}
+.manual-drive-prompt .prompt-allow {
+	background: #d32f2f;
+	color: #fff;
+}
+.manual-drive-prompt .prompt-allow:hover {
+	background: #b71c1c;
+}
+.manual-drive-prompt .prompt-cancel {
+	background: #e0e0e0;
+	color: #222;
+}
+.manual-drive-prompt .prompt-cancel:hover {
+	background: #c8c8c8;
+}
+
 /* Soft limit: axis at boundary styling */
 .axis.at-limit input.pos {
 	color: #cc0000 !important;

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -520,6 +520,10 @@
         this.executeRuntimeCode("manual", { cmd: "exit" });
     };
 
+    FabMoAPI.prototype.manualSoftLimitOverride = function (axis) {
+        this.executeRuntimeCode("manual", { cmd: "softLimitOverride", axis: axis });
+    };
+
     FabMoAPI.prototype.manualMoveFixed = function (axis, speed, distance, second_axis, second_distance) {
         this.executeRuntimeCode("manual", {
             cmd: "fixed",

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -41,6 +41,7 @@ var keyPressed = false;
 var isAuth = false;
 var lastInfoSeen = null;
 var lastErrorSeen = null;
+var lastSoftLimitPromptId = null;
 var consent = "";
 var disconnected = false;
 var calledFromModal = ""; // variable for passing action from Keypad modal to engine
@@ -698,8 +699,19 @@ engine.getVersion(function (err, version) {
                         $(".axis.at-limit").not($limAxis).removeClass("at-limit");
                         $limAxis.addClass("at-limit");
                     }
+                    // Override prompt — third-step escalation. promptId bumps
+                    // each emit so we re-show on a re-prompt but not on every
+                    // status frame after a single emit. Rendered inline inside
+                    // the keypad modal so Allow/Cancel clicks aren't seen as
+                    // click-outside (which would close the keypad).
+                    if (status.softLimit.prompt && status.softLimit.promptId !== lastSoftLimitPromptId) {
+                        lastSoftLimitPromptId = status.softLimit.promptId;
+                        showSoftLimitPrompt(limAxis);
+                    }
                 } else if ($(".axis.at-limit").length) {
                     $(".axis.at-limit").removeClass("at-limit");
+                    lastSoftLimitPromptId = null;
+                    hideSoftLimitPrompt();
                 }
                 if (status["info"] && status["info"]["id"] != lastInfoSeen) {
                     lastInfoSeen = status["info"]["id"];
@@ -1326,6 +1338,8 @@ $(".manual-drive-exit").on("click", function (evt) {
     $(".manual-drive-message").hide();
     $(".manual-drive-message").removeClass("blinking-text");
     $(".axis.at-limit").removeClass("at-limit");
+    $("#soft-limit-prompt").hide();
+    lastSoftLimitPromptId = null;
 
     startManualExit()
         .then(() => {
@@ -2183,6 +2197,32 @@ function hideKeypadMessage() {
     // Show title when hiding message
     document.getElementById("title_goto").style.display = "block";
 }
+
+function showSoftLimitPrompt(axis) {
+    var $prompt = $("#soft-limit-prompt");
+    $prompt.find(".prompt-axis").text(axis);
+    $prompt.data("axis", axis);
+    $prompt.show();
+}
+
+function hideSoftLimitPrompt() {
+    $("#soft-limit-prompt").hide();
+}
+
+// Bind directly on the prompt — the keypad-modal stops click propagation
+// before it reaches `document`, so a delegated handler at the document level
+// never fires.
+$("#soft-limit-prompt").on("click", ".prompt-allow", function (e) {
+    e.stopPropagation();
+    var axis = $("#soft-limit-prompt").data("axis");
+    if (axis) dashboard.engine.manualSoftLimitOverride(axis);
+    hideSoftLimitPrompt();
+});
+
+$("#soft-limit-prompt").on("click", ".prompt-cancel", function (e) {
+    e.stopPropagation();
+    hideSoftLimitPrompt();
+});
 
 function showTitle() {
     document.getElementById("title_goto").style.display = "block";

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -77,6 +77,16 @@ function ManualDriver(drv, st, mode) {
     // Reset on stopMotion so the next press into a known boundary can fire LIM.
     this._limShownThisAttempt = false;
 
+    // Per-axis soft-limit overrides granted via setSoftLimitOverride (bypasses
+    // both the boundary clip and the startMotion short-circuit). Cleared
+    // automatically on keypad exit since the helper is destroyed.
+    this.axisOverrides = {};
+
+    // Per-direction count of consecutive boundary pushes. Drives the LIM →
+    // override-prompt escalation. Reset when the user moves to a different
+    // vector or override is granted.
+    this._limPushCount = {};
+
     // Current trajectory
     this.current_axis = null;
     this.current_speed = null;
@@ -226,15 +236,29 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
     // alive flag set and return without writing to G2.
     // Emit LIM only on the first short-circuit since the last stopMotion —
     // i.e. user is deliberately pushing into a known limit, not just arriving.
+    // On the second deliberate push we escalate to an override prompt.
     if (this._atBoundary &&
         axis === this.currentAxis &&
-        dir === this.currentDirection) {
+        dir === this.currentDirection &&
+        !this.axisOverrides[axis.toLowerCase()]) {
         if (!this._limShownThisAttempt) {
             this._limShownThisAttempt = true;
-            this.emit("softLimit", {
-                axis: this.currentAxis.toUpperCase(),
-                dir: this.currentDirection < 0 ? "minimum" : "maximum",
-            });
+            var dirLabel = this.currentDirection < 0 ? "minimum" : "maximum";
+            var key = this.currentAxis.toUpperCase() + (this.currentDirection < 0 ? "-" : "+");
+            this._limPushCount[key] = (this._limPushCount[key] || 0) + 1;
+            if (this._limPushCount[key] === 1) {
+                this.emit("softLimit", {
+                    axis: this.currentAxis.toUpperCase(),
+                    dir: dirLabel,
+                });
+            } else if (this._limPushCount[key] === 2) {
+                // Once per boundary session — count > 2 stays silent so the
+                // user isn't pestered after dismissing the modal.
+                this.emit("softLimitOverridePrompt", {
+                    axis: this.currentAxis.toUpperCase(),
+                    dir: dirLabel,
+                });
+            }
         }
         this.keep_moving = true;
         return;
@@ -250,6 +274,7 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
             if (this._atBoundary) {
                 this._atBoundary = false;
                 this._limShownThisAttempt = false;
+                this._limPushCount = {};
                 this.emit("softLimitClear");
             }
             this.plannedPos = {};
@@ -280,6 +305,7 @@ ManualDriver.prototype.startMotion = function (axis, speed, second_axis, second_
         // Fresh motion start
         if (this._atBoundary) {
             this._atBoundary = false;
+            this._limPushCount = {};
             this.emit("softLimitClear");
         }
         this.plannedPos = {};
@@ -552,9 +578,52 @@ ManualDriver.prototype._handleNudges = function () {
     if (this.fixedQueue.length > 0) {
         while (this.fixedQueue.length > 0) {
             var move = this.fixedQueue.shift();
+            var axis = move.axis.toUpperCase();
+
+            // Soft-limit gate for nudges. Without this a quick tap could
+            // bypass the boundary check that startMotion/_renewMoves enforce.
+            // Same escalation as continuous jog: silent clip → LIM → prompt.
+            // (Second-axis nudges only check the primary axis, matching
+            // _renewMoves; a mixed-override two-axis nudge is a rare case.)
+            if ("XYZ".indexOf(axis) >= 0
+                && config.machine._cache.envelope
+                && config.machine._cache.softlimits_on
+                && !this.axisOverrides[axis.toLowerCase()]) {
+                var dir = move.distance < 0 ? -1 : 1;
+                var distAbs = Math.abs(move.distance);
+                var margin = this._getMargin(axis, dir);
+                var key = axis + (dir < 0 ? "-" : "+");
+                var dirLabel = dir < 0 ? "minimum" : "maximum";
+
+                if (margin <= 0) {
+                    // Already at boundary — block the nudge and escalate.
+                    this._limPushCount[key] = (this._limPushCount[key] || 0) + 1;
+                    this._atBoundary = true;
+                    this.currentAxis = axis;
+                    this.currentDirection = dir;
+                    if (this._limPushCount[key] === 1) {
+                        this.emit("softLimit", { axis: axis, dir: dirLabel });
+                    } else if (this._limPushCount[key] === 2) {
+                        this.emit("softLimitOverridePrompt", { axis: axis, dir: dirLabel });
+                    }
+                    continue;
+                }
+                if (distAbs > margin) {
+                    // Silent first arrival — clip the nudge to the boundary.
+                    move.distance = dir * margin;
+                    this._atBoundary = true;
+                    this.currentAxis = axis;
+                    this.currentDirection = dir;
+                } else if (this._atBoundary) {
+                    // Nudge fits with headroom — left the boundary.
+                    this._atBoundary = false;
+                    this._limPushCount = {};
+                    this.emit("softLimitClear");
+                }
+            }
+
             this.moving = true;
             this.keep_moving = false;
-            var axis = move.axis.toUpperCase();
 
             if ("XYZABC".indexOf(axis) >= 0) {
                 var moves = ["G91 G61.1"]; // set to exact fixed distance
@@ -636,6 +705,23 @@ ManualDriver.prototype.nudge = function (axis, speed, distance, second_axis, sec
     }
 };
 
+// Grant a temporary soft-limit override for the given axis. Bypasses both
+// directions of the axis so the user can also reverse out of any over-travel
+// they create. Cleared on keypad exit (the helper itself goes away).
+//   axis - Axis letter (e.g. "X")
+ManualDriver.prototype.setSoftLimitOverride = function (axis) {
+    if (!axis) return;
+    var axisLower = String(axis).toLowerCase();
+    this.axisOverrides[axisLower] = true;
+    log.info("Soft limit override granted for axis " + axisLower.toUpperCase() +
+             " (clears on keypad exit)");
+    // Drop boundary state so the next press flows through normal motion.
+    this._atBoundary = false;
+    this._limShownThisAttempt = false;
+    this._limPushCount = {};
+    this.emit("softLimitClear");
+};
+
 // Return true if the machine is moving
 ManualDriver.prototype.isMoving = function () {
     return this.moving;
@@ -714,7 +800,11 @@ ManualDriver.prototype._renewMoves = function (reason) {
             }
 
             // Clip batch to work-coordinate bounds using plannedPos.
-            if (config.machine._cache.envelope && config.machine._cache.softlimits_on) {
+            // Skip the whole block if the primary axis has an override granted —
+            // multi-axis jogs with mixed override are rare enough that letting
+            // the secondary axis through unclipped is acceptable.
+            if (config.machine._cache.envelope && config.machine._cache.softlimits_on
+                && !this.axisOverrides[axisLower]) {
                 var batchDistance = Math.abs(segment) * segmentCount;
                 var margin = this._getMargin(this.currentAxis, this.currentDirection, this.plannedPos[axisLower]);
 

--- a/runtime/manual/index.js
+++ b/runtime/manual/index.js
@@ -100,6 +100,23 @@ ManualRuntime.prototype.enter = function (mode, hideKeypad) {
         }.bind(this)
     );
 
+    // Bumping promptId on each emit lets the dashboard distinguish a fresh
+    // prompt request from a sticky status field after dismissal.
+    this.helper.on(
+        "softLimitOverridePrompt",
+        function (er) {
+            log.info("Soft limit override prompt: " + er.axis + " " + er.dir);
+            var prev = this.machine.status.softLimit || {};
+            this.machine.status.softLimit = {
+                axis: er.axis,
+                dir: er.dir,
+                prompt: true,
+                promptId: (prev.promptId || 0) + 1,
+            };
+            this.machine.emit("status", this.machine.status);
+        }.bind(this)
+    );
+
     // TODO: Determine if this is needed it currently does nothing
     this.helper.enter().then(
         function () {
@@ -154,6 +171,10 @@ ManualRuntime.prototype.executeCode = function (code) {
 
                 case "stop":
                     this.helper.stopMotion();
+                    break;
+
+                case "softLimitOverride":
+                    this.helper.setSoftLimitOverride(code.axis);
                     break;
 
                 case "quit":


### PR DESCRIPTION
Adds a third escalation step on top of the existing silent-clip → LIM warning behavior: after the user pushes into the same boundary twice, an inline prompt offers a temporary per-axis override. Granted overrides bypass both the boundary clip and the startMotion short-circuit until the keypad is closed (the helper goes away on exit, clearing state).

Server: per-direction push count drives the LIM → prompt escalation; emitted exactly once per boundary session so dismissing the modal doesn't pester the user. Override is per-axis (covers + and − so users can also reverse out of any over-travel they create). Nudges go through the same gate so a quick tap can't bypass.

Dashboard: prompt renders inline inside the readout (DRO) area of the keypad modal — keeps Allow/Cancel away from the jog buttons and avoids the dashboard's click-outside-dismiss on the keypad. Direct event binding rather than document delegation since keypad-modal stops click propagation.