### PR TITLE
Add Z-axis soft limit (machine_z=0 ceiling) across jog, queue, previewer

### DIFF
--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -294,13 +294,15 @@ function setFirstCard(job) {
   $('.edit').data('id', firstId);
 
   // Pre-flight soft-limit warning. analyzeJobBounds runs server-side after
-  // submit and tags `softLimitCheck.exceeds` on out-of-envelope jobs; the
-  // play button gets a red exclamation badge so the user can see the
-  // problem before opening the previewer.
-  if (job && job.softLimitCheck && job.softLimitCheck.exceeds) {
+  // submit and saves `bounds` (work-coord extents) on the job; we evaluate
+  // violations live here against the current envelope + g55 so the badge
+  // stays correct after the user re-zeroes (VA/ZT/Z* — see location.js,
+  // which fires `change`/`offsets` to retrigger this render path).
+  var check = evaluateSoftLimits(job && job.bounds, configData);
+  if (check && check.exceeds) {
     var $play = $('.play-button').first();
     $play.addClass('exceeds-limits');
-    var msg = (job.softLimitCheck.violations || [])
+    var msg = check.violations
       .map(function (v) { return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + v.overage.toFixed(2); })
       .join(', ');
     // Real DOM badge (instead of ::after) so it can carry its own tooltip —
@@ -310,6 +312,42 @@ function setFirstCard(job) {
     $badge.find('.exceeds-limits-tooltip').text('Job exceeds soft limits: ' + msg);
     $play.append($badge);
   }
+}
+
+// Mirror of runtime/bounds.js:checkAgainstEnvelope. X/Y use envelope min/max;
+// Z ceiling is hardcoded at machine_z=0 (homed top of travel) and there's no
+// Z min check (low-Z is cut depth, depends on bit length). Returns
+// { exceeds, violations } or null if inputs are missing.
+function evaluateSoftLimits(jobBounds, cfg) {
+  if (!jobBounds || !cfg || !cfg.machine || !cfg.driver) return null;
+  var envelope = cfg.machine.envelope;
+  if (!envelope) return null;
+  var driver = cfg.driver;
+  var g55 = {
+    x: typeof driver.g55x === 'number' ? driver.g55x : 0,
+    y: typeof driver.g55y === 'number' ? driver.g55y : 0,
+    z: typeof driver.g55z === 'number' ? driver.g55z : 0
+  };
+  var violations = [];
+  ['x', 'y'].forEach(function (a) {
+    var bMin = jobBounds.min && jobBounds.min[a];
+    var bMax = jobBounds.max && jobBounds.max[a];
+    if (typeof bMin !== 'number' || typeof bMax !== 'number') return;
+    var off = g55[a];
+    var envMin = envelope[a + 'min'];
+    var envMax = envelope[a + 'max'];
+    if (typeof envMax === 'number' && bMax + off > envMax) {
+      violations.push({ axis: a, direction: 'max', overage: bMax + off - envMax });
+    }
+    if (typeof envMin === 'number' && bMin + off < envMin) {
+      violations.push({ axis: a, direction: 'min', overage: envMin - (bMin + off) });
+    }
+  });
+  var bMaxZ = jobBounds.max && jobBounds.max.z;
+  if (typeof bMaxZ === 'number' && bMaxZ + g55.z > 0) {
+    violations.push({ axis: 'z', direction: 'max', overage: bMaxZ + g55.z });
+  }
+  return { exceeds: violations.length > 0, violations: violations };
 }
 
 
@@ -1037,13 +1075,20 @@ var flattenObject = function(ob) {
   return toReturn;
 };
 
+var configFirstLoaded = false;
 function update() {
   fabmo.getConfig(function(err, data) {
     var ckTransform = false;  // for TRANSFORM state test below
     if(err) {
       console.error(err);
     } else {
+      var wasFirstLoad = !configFirstLoaded;
       configData = data;
+      configFirstLoaded = true;
+      // Soft-limit badges (setFirstCard) need configData to evaluate live.
+      // initialLoad runs before this callback resolves on page load, so the
+      // first render has no badge — repaint the queue once configData lands.
+      if (wasFirstLoad) updateQueue();
         ['opensbp'].forEach(function(branchname) {
                 branch = flattenObject(data[branchname]);
           for(key in branch) {
@@ -1149,10 +1194,20 @@ $(document).ready(function() {
     });
 
     // Server fires `change`/`jobs` after async work mutates a job record
-    // (e.g. analyzeJobBounds saving softLimitCheck post-submit). Without
-    // this listener the queue card never picks up the soft-limit badge.
+    // (e.g. analyzeJobBounds saving bounds post-submit). Without this
+    // listener the queue card never picks up the soft-limit badge.
+    // `offsets` fires when VA/ZT/Z* commands change g55 or machine base
+    // coords — we refresh configData first so live-eval sees fresh g55,
+    // then re-render so the badge reflects the new ceiling.
     fabmo.on('change', function (topic) {
-        if (topic === 'jobs') updateQueue();
+        if (topic === 'jobs') {
+            updateQueue();
+        } else if (topic === 'offsets') {
+            fabmo.getConfig(function (err, data) {
+                if (!err) configData = data;
+                updateQueue();
+            });
+        }
     });
 
     // The queue will update when the status report comes in

--- a/dashboard/apps/previewer.fma/js/app.js
+++ b/dashboard/apps/previewer.fma/js/app.js
@@ -779,6 +779,7 @@ function nowPreviewJob() {
       cached_Config.machine.envelope,
       cached_Config.driver.g55x,
       cached_Config.driver.g55y,
+      cached_Config.driver.g55z,
       cached_Config.machine.units
     );
 

--- a/dashboard/apps/previewer.fma/js/viewer.js
+++ b/dashboard/apps/previewer.fma/js/viewer.js
@@ -81,10 +81,10 @@ module.exports = function(container) {
   // Used to flag files whose cutting extents would exceed the machine envelope.
   var softLimits = null;
 
-  self.setSoftLimits = function (envelope, g55x, g55y, units) {
+  self.setSoftLimits = function (envelope, g55x, g55y, g55z, units) {
       softLimits = {
           envelope: envelope,
-          g55: { x: g55x || 0, y: g55y || 0 },
+          g55: { x: g55x || 0, y: g55y || 0, z: g55z || 0 },
           units: units || ''
       };
   }
@@ -116,6 +116,16 @@ module.exports = function(container) {
               violations.push({ axis: a, direction: 'min', overage: envMin - machineMin });
           }
       });
+
+      // Z ceiling is fixed at machine_z = 0 (homed top) regardless of envelope.zmax.
+      // No Z min check — low Z in a CAM file is cut depth and depends on bit length.
+      var bMaxZ = bounds.max.z;
+      if (typeof bMaxZ === 'number') {
+          var machineMaxZ = bMaxZ + g55.z;
+          if (machineMaxZ > 0) {
+              violations.push({ axis: 'z', direction: 'max', overage: machineMaxZ });
+          }
+      }
       if (violations.length) {
           self.gui.showSoftLimitWarning(violations, softLimits.units);
       } else {

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -26,12 +26,16 @@ function analyzeJobBounds(job) {
             var g55 = {
                 x: config.driver.get("g55x") || 0,
                 y: config.driver.get("g55y") || 0,
+                z: config.driver.get("g55z") || 0,
             };
             var check = bounds.checkAgainstEnvelope(result.bounds, envelope, g55);
             db.Job.getById(job._id, function (err, fresh) {
                 if (err || !fresh) return;
+                // Only persist work-coord bounds; the dashboard re-evaluates
+                // violations live against current envelope + g55 so the badge
+                // stays correct after VA/ZT/Z* offset changes (see job_manager.js
+                // and runtime/opensbp/commands/location.js).
                 fresh.bounds = result.bounds;
-                fresh.softLimitCheck = check;
                 fresh.save(function () {});
                 log.info(
                     "Bounds for job " + job._id + ": exceeds=" + check.exceeds +

--- a/runtime/bounds.js
+++ b/runtime/bounds.js
@@ -116,6 +116,20 @@ function checkAgainstEnvelope(bounds, envelope, g55) {
             violations.push({ axis: a, direction: "min", overage: envMin - (bMin + off) });
         }
     });
+
+    // Z ceiling is fixed at machine_z = 0 (homed top of travel) regardless of
+    // envelope.zmax — work-Z zero shifts every bit change, so the only stable
+    // ceiling is the invariant table-base top. No Z min check: low-Z in a CAM
+    // file is cut depth, which depends on bit length and would noise-fire on
+    // normal jobs.
+    var bMaxZ = bounds.max.z;
+    if (typeof bMaxZ === "number") {
+        var offZ = (g55 && typeof g55.z === "number") ? g55.z : 0;
+        if (bMaxZ + offZ > 0) {
+            violations.push({ axis: "z", direction: "max", overage: bMaxZ + offZ });
+        }
+    }
+
     return { exceeds: violations.length > 0, violations: violations };
 }
 

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -744,7 +744,11 @@ ManualDriver.prototype._getMargin = function (axis, direction, pos) {
     if (envelope[axisLower + "min"] === undefined || envelope[axisLower + "max"] === undefined) return Infinity;
     // Envelope is in table (G53) coords; convert to work coords by subtracting g55 offset.
     var workMin = envelope[axisLower + "min"] - offset;
-    var workMax = envelope[axisLower + "max"] - offset;
+    // Z ceiling is fixed at machine_z = 0 (homed top of travel) regardless of
+    // envelope.zmax — work-Z zero shifts every bit change, so the only stable
+    // ceiling is the invariant table-base top.
+    var zmaxTable = (axisLower === "z") ? 0 : envelope[axisLower + "max"];
+    var workMax = zmaxTable - offset;
 
     var margin;
     if (direction < 0) {

--- a/runtime/opensbp/commands/location.js
+++ b/runtime/opensbp/commands/location.js
@@ -104,6 +104,14 @@ function offsets(args, callback) {
                     await config.driver.setManyWrapper(setVA_G2); // syncs FabMo and G2 configs
                 }
                 this.CUR_RUNTIME.emit_gcode("M0");
+                // Notify the dashboard that offsets / machine base changed so consumers
+                // (e.g. job-manager soft-limit badges) can re-evaluate against fresh g55.
+                // Required at call-time to avoid circular load with machine.js.
+                try {
+                    require("../../../machine").machine.emit("change", "offsets");
+                } catch (e) {
+                    log.debug("offsets change emit skipped: " + e.message);
+                }
                 if (callback) {
                     callback(log.debug("Completed offsets setting"));
                 }


### PR DESCRIPTION
Z homes at top-of-travel so machine_z=0 is the only invariant ceiling — work-Z zero shifts every bit change, so binding the limit there (not to envelope.zmax) is what users actually need. Floor on Z is suppressed because low-Z in a CAM file is cut depth and depends on bit length, so it would noise-fire on normal jobs.

Manual jog (runtime/manual/driver.js): _getMargin overrides axis-Z ceiling to 0 regardless of envelope.zmax. Existing axis-agnostic clip, LIM, and per-axis override flow handles Z without further changes.

File pre-check (runtime/bounds.js): checkAgainstEnvelope adds a Z max check (no min) using the same fixed-0 ceiling rule. routes/jobs.js stops persisting softLimitCheck since it would go stale after re-zero; only work-coord bounds are saved on the job now.

Re-evaluation on offset change (runtime/opensbp/commands/location.js): offsets() emits machine `change`/`offsets` after VA, ZT, and all Z* zeroing commands complete. Single hook covers every command that can shift the violation via the lower (G55) or upper (G28.3) register.

Job Manager dashboard: setFirstCard evaluates violations live from job.bounds against current configData each render — no stored softLimitCheck. Listens for `change`/`offsets` to refresh configData and re-render so the badge tracks the user re-zeroing while jobs are queued. First-load race fix: configData is async, so updateQueue re-fires the first time it lands so the initial render gets a badge.

Previewer: setSoftLimits now also takes g55z; checkSoftLimits adds the Z max rule. Refresh-on-offsets-change in the previewer is intentionally deferred to a follow-up branch.