### PR TITLE
Add per-output ON/OFF policies (file_start, file_end, command, timed)

### DIFF
--- a/config/machine_config.js
+++ b/config/machine_config.js
@@ -48,6 +48,24 @@ MachineConfig.prototype.init = function (machine, callback) {
                     calibrated: false,
                 };
             }
+            if (this._cache && !("outputs" in this._cache)) {
+                // Outputs 1, 2, 4 have hardcoded labels and runtime ignores
+                // their policy. The other rows are configurable in the
+                // configuration app's Outputs tab.
+                var hardcoded = { "1": "Spindle 1", "2": "Spindle 2", "4": "Arm Motion" };
+                this._cache.outputs = {};
+                for (var i = 1; i <= 12; i++) {
+                    this._cache.outputs[String(i)] = {
+                        label: hardcoded[i] || ("Output " + i),
+                        // Output 4 (Arm Motion) goes on at file start; everything
+                        // else stays manual. All outputs auto-off at file end.
+                        on_mode: i === 4 ? "file_start" : "command",
+                        off_mode: "file_end",
+                        on_seconds: 0,
+                        off_seconds: 0,
+                    };
+                }
+            }
             if (typeof callback === "function") callback(err);
         }.bind(this)
     );

--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -35,6 +35,8 @@
           </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel3" role="tab" tabindex="0" aria-selected="false" controls="tabpanel3">Inputs</a>
           </li>
+          <li class="tab-title" role="presentational"><a href="#tabpanel8" role="tab" tabindex="0" aria-selected="false" controls="tabpanel8">Outputs</a>
+          </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel6" role="tab" tabindex="0" aria-selected="false" controls="tabpanel6">Apps</a>
           </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel7" role="tab" tabindex="0" aria-selected="false" controls="tabpanel7">Users</a>
@@ -1115,6 +1117,12 @@
             </div>
           </fieldset>
         </div>
+      </section>
+
+
+      <!-- OUTPUTS ----------------------------------------------------------------------------------------------- -->
+      <section role="tabpanel" aria-hidden="true" class="content" id="tabpanel8">
+        <div id="outputs-list"><!-- fieldsets injected by configuration.js --></div>
       </section>
 
 

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -161,6 +161,17 @@ function update() {
         data.engine.profile = 'Default';
       }
       profilesList.val(data.engine.profile);
+
+      // Outputs tab: sync seconds-input visibility against the just-populated
+      // mode dropdowns. Done here (not on a timer) so initial render and any
+      // external config change refresh visibility correctly.
+      if (typeof syncSecondsVisibility === 'function') {
+        for (var nOut = 1; nOut <= 12; nOut++) {
+          if (OUTPUT_HARDCODED[nOut]) continue;
+          syncSecondsVisibility(nOut, 'on');
+          syncSecondsVisibility(nOut, 'off');
+        }
+      }
     }
   });
 }
@@ -391,6 +402,152 @@ $('#firmware-input').change(function(evt) {
 });
 
 
+// Outputs whose behavior is hardcoded — labels are fixed and modes are not
+// user-configurable. The runtime ignores their saved policy entirely (see
+// runtime/output_policy.js HARDCODED).
+var OUTPUT_HARDCODED = { 1: "Spindle 1", 2: "Spindle 2", 4: "Arm Motion" };
+
+var ON_MODES = [
+    { value: "file_start", label: "File Start" },
+    { value: "command", label: "Command" },
+    { value: "timed_after_file_end", label: "Timed after file end" }
+];
+var OFF_MODES = [
+    { value: "file_end", label: "File End" },
+    { value: "command", label: "Command" },
+    { value: "timed_after_file_end", label: "Timed after file end" }
+];
+
+function buildOutputFieldset(n) {
+    var isLocked = !!OUTPUT_HARDCODED[n];
+
+    // Legend: "Output N" + label. For locked outputs the label is fixed text
+    // with a "(locked)" tag; for configurable ones it's an inline input the
+    // user can rename.
+    var legendInner;
+    if (isLocked) {
+        legendInner =
+            'Output ' + n +
+            ' <span style="font-weight:normal;">' + OUTPUT_HARDCODED[n] + '</span>' +
+            ' <span style="color:#999; font-size:0.85em; font-weight:normal;">(locked)</span>' +
+            '<input type="hidden" id="machine-outputs-' + n + '-label" value="' + OUTPUT_HARDCODED[n] + '">';
+    } else {
+        legendInner =
+            'Output ' + n +
+            ' <input type="text" id="machine-outputs-' + n + '-label" class="machine-output"' +
+            ' style="display:inline-block; width:auto; margin:0 0 0 6px; height:1.8em; font-weight:normal;">';
+    }
+
+    function buildModeBlock(side, label, modes) {
+        var opts = modes.map(function (m) {
+            return '<option value="' + m.value + '">' + m.label + '</option>';
+        }).join('');
+        var lockedAttr = isLocked ? ' disabled' : '';
+        var selectCls = isLocked ? '' : ' class="machine-output output-mode" data-side="' + side + '" data-output="' + n + '"';
+        var secondsCls = isLocked ? '' : ' class="machine-output output-seconds"';
+        return [
+            '<div class="large-4 columns">',
+              '<div class="row collapse">',
+                '<label>' + label,
+                  '<select id="machine-outputs-' + n + '-' + side + '_mode"' + selectCls + lockedAttr + '>' + opts + '</select>',
+                '</label>',
+                '<input type="number" id="machine-outputs-' + n + '-' + side + '_seconds" min="0" step="0.1"' + secondsCls + lockedAttr +
+                  ' placeholder="seconds" style="display:none; margin-top:4px;">',
+              '</div>',
+            '</div>'
+        ].join('');
+    }
+
+    var toggleBlock = [
+        '<div class="large-4 columns">',
+          '<div class="row collapse">',
+            '<label>Test',
+              '<button type="button" class="button output-toggle" data-output="' + n + '"',
+                ' id="output-toggle-' + n + '"',
+                // Match the adjacent <select> dimensions so the row aligns:
+                ' style="width:100%; height:2.3125rem; padding:0; margin:0;">OFF</button>',
+            '</label>',
+          '</div>',
+        '</div>'
+    ].join('');
+
+    return [
+        '<div class="row">',
+          '<fieldset>',
+            '<legend>' + legendInner + '</legend>',
+            buildModeBlock('on', 'ON Condition', ON_MODES),
+            buildModeBlock('off', 'OFF Condition', OFF_MODES),
+            toggleBlock,
+          '</fieldset>',
+        '</div>'
+    ].join('');
+}
+
+// Toggle the seconds input visibility for a given (output, side) pair based
+// on the mode dropdown value. Called on init (to set initial visibility from
+// loaded config) and on every dropdown change.
+function syncSecondsVisibility(n, side) {
+    var mode = $('#machine-outputs-' + n + '-' + side + '_mode').val();
+    var $secs = $('#machine-outputs-' + n + '-' + side + '_seconds');
+    $secs.css('display', mode === 'timed_after_file_end' ? '' : 'none');
+}
+
+function setupOutputsTab() {
+    var $list = $('#outputs-list');
+    if (!$list.length) return;
+    var html = '';
+    for (var n = 1; n <= 12; n++) html += buildOutputFieldset(n);
+    $list.html(html);
+
+    // Generic save: any change in a row writes back to machine.outputs.<n>.<key>.
+    // setConfig already splits the id by "-" and rebuilds the nested object,
+    // so machine-outputs-3-on_mode → { machine: { outputs: { 3: { on_mode: ... } } } }.
+    $list.on('change', '.machine-output', function () {
+        setConfig(this.id, this.value);
+    });
+
+    // Show/hide seconds inputs whenever a mode changes.
+    $list.on('change', '.output-mode', function () {
+        var n = $(this).data('output');
+        var side = $(this).data('side');
+        syncSecondsVisibility(n, side);
+    });
+
+    // Toggle button: send SO,N,<opposite-of-current-state>. The SO command is
+    // always permitted regardless of policy; the firmware will reflect the
+    // new state in the next status report and updateOutputStates repaints.
+    $list.on('click', '.output-toggle', function () {
+        var n = $(this).data('output');
+        var $btn = $(this);
+        var nextState = $btn.hasClass('output-on') ? 0 : 1;
+        fabmo.runSBP('SO,' + n + ',' + nextState + '\n');
+    });
+
+    // Initial visibility is set inside update()'s getConfig callback
+    // (see syncSecondsVisibility loop near the end of update()) once the
+    // dropdown values have been populated from the loaded config.
+}
+
+// Live state — drives each output's toggle button label and color from
+// status.out1..out12 (piped through the engine status report; see machine.js
+// status init). Button text shows the *current* state; clicking it toggles
+// to the opposite (handled in setupOutputsTab).
+function updateOutputStates(status) {
+    if (!status) return;
+    for (var n = 1; n <= 12; n++) {
+        var v = status['out' + n];
+        var $btn = $('#output-toggle-' + n);
+        if (!$btn.length) continue;
+        if (v === 1 || v === true) {
+            $btn.text('ON').addClass('output-on')
+                .css({ background: '#4caf50', color: '#fff' });
+        } else {
+            $btn.text('OFF').removeClass('output-on')
+                .css({ background: '#888', color: '#fff' });
+        }
+    }
+}
+
 $(document).ready(function() {
     $(document).foundation();
 
@@ -402,10 +559,13 @@ $(document).ready(function() {
     registerUnitLabel('.inrev_mmrev_label', 'in/rev', 'mm/rev');
     registerUnitLabel('.inpm3_mmpm3_label', 'in/min<sup>3</sup>', 'mm/min<sup>3</sup>');
 
+    setupOutputsTab();
+
     fabmo.on('status', function(status) {
       update();
+      updateOutputStates(status);
     });
-    
+
     // Trigger a status update to get the ball rolling
     fabmo.requestStatus();
 

--- a/machine.js
+++ b/machine.js
@@ -30,6 +30,7 @@ var db = require("./db");
 var log = require("./log").logger("machine");
 var config = require("./config");
 var updater = require("./updater");
+var outputPolicy = require("./runtime/output_policy");
 var u = require("./util");
 var async = require("async");
 var canQuit = false;
@@ -1454,6 +1455,7 @@ Machine.prototype.setState = function (source, newstate, stateinfo) {
                             // ... for a few cases such as coming out of probing on Stop input]
                             log.debug("... otherwise send final lines from machine");
                             this.driver.command({ out4: 0 }); // Permissive relay
+                            outputPolicy.onFileEnd(this); // Configurable per-output file-end policy (skips 1/2/4)
                             this.driver.command({ gc: "m30" }); // Generate End
                             log.debug("call MPO from machine");
                             this.driver._primed = false; // * important to clear for unusual endings
@@ -1534,6 +1536,15 @@ Machine.prototype.setState = function (source, newstate, stateinfo) {
                 }
                 break;
             case "running":
+                // Detect idle->running specifically — paused->running and other
+                // transitions back into running shouldn't re-fire ON policies.
+                // status.state is still the previous state at this point;
+                // it gets updated to newstate after the switch (line ~1553).
+                if (this.status.state === "idle") {
+                    outputPolicy.onFileStart(this);
+                }
+                this.status.resumeFlag = false;
+                break;
             case "limit":
             case "lock":
             case "interlock":

--- a/profiles/default/config/machine.json
+++ b/profiles/default/config/machine.json
@@ -32,6 +32,20 @@
 		"zmin" : -2,
 		"zmax" : 6
 	},
+	"outputs" : {
+		"1":  { "label": "Spindle 1",   "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"2":  { "label": "Spindle 2",   "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"3":  { "label": "Output 3",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"4":  { "label": "Arm Motion",  "on_mode": "file_start", "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"5":  { "label": "Output 5",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"6":  { "label": "Output 6",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"7":  { "label": "Output 7",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"8":  { "label": "Output 8",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"9":  { "label": "Output 9",    "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"10": { "label": "Output 10",   "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"11": { "label": "Output 11",   "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 },
+		"12": { "label": "Output 12",   "on_mode": "command",    "off_mode": "file_end", "on_seconds": 0, "off_seconds": 0 }
+	},
 	"cameraCalibration" : {
 		"corners": {
 			"tl": { "x": 0, "y": 0 },

--- a/runtime/output_policy.js
+++ b/runtime/output_policy.js
@@ -1,0 +1,104 @@
+/*
+ * runtime/output_policy.js
+ *
+ * Per-output ON/OFF policy enforcement at file-start and file-end transitions.
+ * Configuration lives at machine.outputs (see profiles/default/config/machine.json):
+ *   { "<N>": { label, on_mode, off_mode, on_seconds, off_seconds } }
+ *
+ * Supported modes (this branch — "input_trigger" reserved for follow-up):
+ *   on_mode:  "file_start" | "command" | "timed_after_file_end"
+ *   off_mode: "file_end"   | "command" | "timed_after_file_end"
+ *
+ * Outputs 1, 2, 4 are hardcoded (Spindle 1, Spindle 2, Arm Motion) and the
+ * runtime ignores their policy entirely — their existing behavior in machine.js
+ * (notably out4:0 at file end) is unchanged.
+ *
+ * `command` mode means the runtime takes no automatic action; the SO command
+ * (always permitted) is the only way to drive the output. SO commands are not
+ * gated by policy.
+ */
+"use strict";
+
+var log = require("../log").logger("output_policy");
+
+var HARDCODED = { 1: true, 2: true, 4: true };
+var POLICY_OUTPUTS = [3, 5, 6, 7, 8, 9, 10, 11, 12];
+
+// Pending timers from the most recent file-end. Keyed by `<n>:<on|off>` so
+// each output can have at most one queued action per direction. Cleared on
+// the next file-start so timers don't fire mid-job.
+var pendingTimers = {};
+
+function clearPending() {
+    Object.keys(pendingTimers).forEach(function (key) {
+        clearTimeout(pendingTimers[key]);
+        delete pendingTimers[key];
+    });
+}
+
+function driveOutput(machine, n, value) {
+    var cmd = {};
+    cmd["out" + n] = value;
+    machine.driver.command(cmd);
+    log.debug("output policy: out" + n + " -> " + value);
+}
+
+function getPolicy(n) {
+    var config = require("../config");
+    var outputs = config.machine && config.machine.get && config.machine.get("outputs");
+    if (!outputs) return null;
+    return outputs[String(n)] || null;
+}
+
+// File start: cancel any pending timed actions from the previous job, then
+// drive ON for any output whose on_mode is "file_start".
+function onFileStart(machine) {
+    clearPending();
+    POLICY_OUTPUTS.forEach(function (n) {
+        if (HARDCODED[n]) return;
+        var p = getPolicy(n);
+        if (!p) return;
+        if (p.on_mode === "file_start") {
+            driveOutput(machine, n, 1);
+        }
+    });
+}
+
+// File end: drive OFF for "file_end" off_mode immediately. Schedule timed
+// actions for either side configured with "timed_after_file_end". A non-
+// positive on_seconds/off_seconds is treated as immediate.
+function onFileEnd(machine) {
+    POLICY_OUTPUTS.forEach(function (n) {
+        if (HARDCODED[n]) return;
+        var p = getPolicy(n);
+        if (!p) return;
+
+        if (p.off_mode === "file_end") {
+            driveOutput(machine, n, 0);
+        } else if (p.off_mode === "timed_after_file_end") {
+            var offSec = Number(p.off_seconds) || 0;
+            scheduleTimed(machine, n, "off", offSec, 0);
+        }
+
+        if (p.on_mode === "timed_after_file_end") {
+            var onSec = Number(p.on_seconds) || 0;
+            scheduleTimed(machine, n, "on", onSec, 1);
+        }
+    });
+}
+
+function scheduleTimed(machine, n, side, seconds, value) {
+    var key = n + ":" + side;
+    if (pendingTimers[key]) clearTimeout(pendingTimers[key]);
+    if (seconds <= 0) {
+        driveOutput(machine, n, value);
+        return;
+    }
+    pendingTimers[key] = setTimeout(function () {
+        delete pendingTimers[key];
+        driveOutput(machine, n, value);
+    }, seconds * 1000);
+}
+
+exports.onFileStart = onFileStart;
+exports.onFileEnd = onFileEnd;


### PR DESCRIPTION
Adds a configurable policy layer for the 12 controller outputs: each output picks an ON condition (File Start / Command / Timed after file end) and an OFF condition (File End / Command / Timed after file end), with optional per-side delays. The SO command remains unconditionally allowed regardless of policy. Outputs 1, 2, and 4 (Spindle 1, Spindle 2, Arm Motion) are flagged hardcoded — the runtime ignores their saved policy so existing behavior (notably the out4:0 reset at file end) is preserved.

Schema (profiles/default/config/machine.json + config/machine_config.js): nested `outputs` block keyed "1".."12" with label, on_mode, off_mode, on_seconds, off_seconds. Default profile carries the canonical values; machine_config.js seeds the same shape for non-default profiles that don't define `outputs` so util.extend will accept client updates. Default ON for output 4 is file_start; everything else is command; all OFF defaults are file_end.

Runtime (runtime/output_policy.js + machine.js):
- onFileStart fires inside setState's case "running" when the previous state was "idle" — paused→running and other re-entries don't re-fire ON policies. It clears any pending timers from a prior job.
- onFileEnd fires inside the existing case "idle" default branch right after the out4:0 line. Drives `file_end` outputs OFF immediately and schedules timers for `timed_after_file_end` on either side.
- Hardcoded outputs (1, 2, 4) are skipped explicitly; the existing out4:0 line is unchanged.

Configuration UI (configuration.fma):
new Outputs tab with a fieldset per output, mirroring the Inputs tab layout. Editable label inline with the legend (locked text + "(locked)" tag for outputs 1, 2, 4). ON/OFF dropdowns with a "seconds" input that appears only when "Timed after file end" is selected — visibility is synced inside update()'s getConfig callback so initial render reflects loaded values without a timer hack. Each fieldset has a Test button (matches dropdown height and column width) that fires SO,N,<opposite> based on the live state from the status report.