### PR TITLE
Add input simulation (debug mode) for OpenSBP files

### DIFF
--- a/dashboard/apps/editor.fma/index.html
+++ b/dashboard/apps/editor.fma/index.html
@@ -97,10 +97,11 @@
             <li><a id="lang-gcode" href="#languagegcode">G-Code</a></li>
           </ul>
         </li>
-        <li class="has-dropdown" id="execute-menu"> 
+        <li class="has-dropdown" id="execute-menu">
           <a href="#executemenu" class="success">Execute/Save</a>
-          <ul class="dropdown"> 
+          <ul class="dropdown">
             <li><a id="submit-immediate" href="#submitimmediate">Run Code Immediately (Ctrl+Enter)</a></li>
+            <li><a id="submit-debug" href="#submitdebug">Run in Debug Mode (input simulation)</a></li>
             <li><a id="submit-job" href="#submitasjob">Save and Submit as Separate New Job</a></li>
           </ul>
         </li>

--- a/dashboard/apps/editor.fma/js/editor.js
+++ b/dashboard/apps/editor.fma/js/editor.js
@@ -44,6 +44,18 @@ require('./cm-fabmo-modes.js');
       }
     }
 
+    function executeDebug() {
+      $("#execute-menu").hide();
+      var text = editor.getValue();
+      overrideDirty = false;
+      if (lang !== 'opensbp') {
+        fabmo.notify('warn', 'Debug mode (input simulation) is only available for OpenSBP files.');
+        return;
+      }
+      fabmo.notify('info', 'Executing OpenSBP program in debug mode.');
+      fabmo.runSBPDebug(text);
+    }
+
     function supports_html5_storage() {
       try {
         return 'localStorage' in window && window['localStorage'] !== null;
@@ -386,6 +398,18 @@ require('./cm-fabmo-modes.js');
           isRunCodeImmediatelyClick = false;
         });
 
+        // "Run in Debug Mode" — same dirty-handling as Run Immediately
+        $(document).on('mousedown', '#submit-debug', function() {
+          isRunCodeImmediatelyClick = true;
+          if (!editor.hasFocus() && !alreadyBlurred) {
+            handleEditorBlur();
+          }
+          alreadyBlurred = false;
+        });
+        $(document).on('mouseup', '#submit-debug', function() {
+          isRunCodeImmediatelyClick = false;
+        });
+
         // And for "Macro Save" button
         $(document).on('mousedown', '#macro-save', function() {
           isMacroSaveClick = true;
@@ -454,6 +478,13 @@ require('./cm-fabmo-modes.js');
       if (!isDirty || overrideDirty) {
         console.log("Run Code Immediately from click");
         execute();
+      }
+      evt.preventDefault();
+    });
+    $("#submit-debug").click(function(evt) {
+      if (!isDirty || overrideDirty) {
+        console.log("Run in Debug Mode from click");
+        executeDebug();
       }
       evt.preventDefault();
     });

--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -553,6 +553,10 @@
     </div>
 
     <div class="footBar fabmo-file-control">
+      <div class="sim-input-row" id="sim-input-row" style="display:none;">
+        <span class="sim-input-label">DEBUG — click to toggle inputs:</span>
+        <div class="sim-inputs"></div>
+      </div>
       <div class="currentContainer">
         <p class="currentJobTitle"></p>
       </div>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1163,6 +1163,59 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
     overflow: hidden; /* Hide buttons when footer is closed */
 }
 
+/* ========== DEBUG MODE — Simulated Input trigger row ========== */
+.sim-input-row {
+    position: absolute;
+    top: 8px;
+    left: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    color: #ffe217;
+    font-family: Arial, sans-serif;
+    font-size: 12px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.sim-input-label {
+    font-weight: bold;
+    letter-spacing: 0.5px;
+}
+
+.sim-inputs {
+    display: flex;
+    gap: 4px;
+}
+
+.sim-input-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 24px;
+    border-radius: 4px;
+    background: #555;
+    color: #ddd;
+    border: solid #222 1px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+}
+
+.sim-input-btn:hover {
+    background: #666;
+}
+
+.sim-input-btn.active {
+    background: #32B433;
+    color: #ffffff;
+    border-color: #00A600;
+}
+
 /* Container for both button groups - centers them with gap */
 .footer-buttons-container {
     display: flex;

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -884,6 +884,39 @@ define(function (require) {
         );
 
         this._registerHandler(
+            "runSBPDebug",
+            function (text, callback) {
+                this.engine.sbpDebug(
+                    text,
+                    function (err, result) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, result);
+                        }
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
+
+        this._registerHandler(
+            "setSimInput",
+            function (data, callback) {
+                this.engine.setSimInput(
+                    data.inp,
+                    data.state,
+                    function (err, result) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, result);
+                        }
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
+
+        this._registerHandler(
             "getUpdaterConfig",
             function (data, callback) {
                 this.engine.getUpdaterConfig(
@@ -1437,7 +1470,52 @@ define(function (require) {
             this._fireEvent("job_start", null);
         }
         this.status = status;
+        this._renderSimInputs(status);
         this._fireEvent("status", status);
+    };
+
+    // Render the debug-mode input trigger row in the footer when the SBP runtime
+    // is running in simulation mode. Each button toggles a simulated input value.
+    Dashboard.prototype._renderSimInputs = function (status) {
+        var $row = $("#sim-input-row");
+        if (!$row.length) return;
+        if (!status || !status.simulation_mode) {
+            $row.hide();
+            return;
+        }
+        var $container = $row.find(".sim-inputs");
+        if (!$container.children().length) {
+            for (var i = 1; i <= 12; i++) {
+                $('<div class="sim-input-btn" data-inp="' + i + '">' + i + "</div>").appendTo($container);
+            }
+            var self = this;
+            // Momentary buttons: press to set ON, release/leave to set OFF.
+            // Touch events mirror mouse events for tablet use.
+            var setInput = function (inp, state) {
+                self.engine.setSimInput(inp, state, function (err) {
+                    if (err) console.warn("setSimInput failed:", err);
+                });
+            };
+            var press = function (e) {
+                e.preventDefault();
+                setInput(parseInt($(this).attr("data-inp"), 10), true);
+            };
+            var release = function (e) {
+                e.preventDefault();
+                var inp = parseInt($(this).attr("data-inp"), 10);
+                // Only release if currently held (avoids redundant OFF on mouseleave after mouseup)
+                var sim = (self.status && self.status.simulated_inputs) || {};
+                if (sim[inp]) setInput(inp, false);
+            };
+            $container.on("mousedown touchstart", ".sim-input-btn", press);
+            $container.on("mouseup mouseleave touchend touchcancel", ".sim-input-btn", release);
+        }
+        var sim = status.simulated_inputs || {};
+        $container.children().each(function () {
+            var inp = parseInt($(this).attr("data-inp"), 10);
+            $(this).toggleClass("active", !!sim[inp]);
+        });
+        $row.show();
     };
 
     // Brings up the DRO (if separate from the keypad) in the dashboard

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -1044,6 +1044,14 @@
         this._call("runSBP", text, callback);
     };
 
+    FabMoDashboard.prototype.runSBPDebug = function (text, callback) {
+        this._call("runSBPDebug", text, callback);
+    };
+
+    FabMoDashboard.prototype.setSimInput = function (inp, state, callback) {
+        this._call("setSimInput", { inp: inp, state: state }, callback);
+    };
+
     FabMoDashboard.prototype.connectToWifi = function (ssid, key, callback) {
         this._call("connectToWifi", { ssid: ssid, key: key }, callback);
     };

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -469,6 +469,17 @@
         this.runCode("sbp", code, callback);
     };
 
+    // Run SBP code in input-simulation (debug) mode.
+    FabMoAPI.prototype.sbpDebug = function (code, callback) {
+        var data = { cmd: code, runtime: "sbp", debug: true };
+        this._post("/code", data, callback, callback);
+    };
+
+    // Force a simulated input value during a debug-mode run.
+    FabMoAPI.prototype.setSimInput = function (inp, state, callback) {
+        this._post("/code/sim_input", { inp: inp, state: !!state }, callback, callback);
+    };
+
     FabMoAPI.prototype.goto = function (move, callback) {
         this.executeRuntimeCode("manual", { cmd: "goto", move: move });
     };

--- a/machine.js
+++ b/machine.js
@@ -1113,7 +1113,7 @@ Machine.prototype.fire = function (force) {
         case "runtimeCode":
             var name = action.payload.name;
             var code = action.payload.code;
-            this._executeRuntimeCode(name, code);
+            this._executeRuntimeCode(name, code, action.payload.options);
             break;
 
         case "runFile":
@@ -1357,6 +1357,14 @@ Machine.prototype._runFile = function (filename) {
     var runtime = this.gcode_runtime;
     if (ext === ".sbp") {
         runtime = this.sbp_runtime;
+    }
+
+    // Submitted jobs always run in normal (non-debug) mode — clear any
+    // leftover sim flag from a previous /code debug run.
+    if (this.sbp_runtime && "simulation_mode" in this.sbp_runtime) {
+        this.sbp_runtime.simulation_mode = false;
+        this.status.simulation_mode = false;
+        this.status.simulated_inputs = {};
     }
 
     // Set the appropriate runtime
@@ -1753,8 +1761,10 @@ Machine.prototype.runNextJob = function (callback) {
 // runtimeName - the name of a valid runtime
 //        code - can be anything, it is runtime specific.
 //               example: if you pass gcode to the gcode runtime, it runs g-code.
-Machine.prototype.executeRuntimeCode = function (runtimeName, code) {
+//     options - optional. { debug: true } enables input simulation on the SBP runtime.
+Machine.prototype.executeRuntimeCode = function (runtimeName, code, options) {
     interlockBypass = false;
+    options = options || {};
     runtime = this.getRuntime(runtimeName);
     if (runtime === undefined) {
         log.debug("Rejecting attempt to execute runtime code with no defined runtime.");
@@ -1764,7 +1774,7 @@ Machine.prototype.executeRuntimeCode = function (runtimeName, code) {
     var needsAuth = runtime.needsAuth(code);
     if (needsAuth) {
         if (this.status.auth) {
-            return this._executeRuntimeCode(runtimeName, code);
+            return this._executeRuntimeCode(runtimeName, code, options);
         } else {
             this.arm(
                 {
@@ -1772,20 +1782,22 @@ Machine.prototype.executeRuntimeCode = function (runtimeName, code) {
                     payload: {
                         name: runtimeName,
                         code: code,
+                        options: options,
                     },
                 },
                 config.machine.get("auth_timeout")
             );
         }
     } else {
-        this._executeRuntimeCode(runtimeName, code);
+        this._executeRuntimeCode(runtimeName, code, options);
     }
 };
 
 // Just run this SBP code immediately
-// string - the code to run
-Machine.prototype.sbp = function (string) {
-    this.executeRuntimeCode("sbp", string);
+// string  - the code to run
+// options - optional. { debug: true } runs in input-simulation mode.
+Machine.prototype.sbp = function (string, options) {
+    this.executeRuntimeCode("sbp", string, options);
 };
 
 // Just run this gcode immediately
@@ -1970,9 +1982,20 @@ Machine.prototype.watchConfig = function () {
  * For documentation of these functions, see their corresponding "public" methods above.
  */
 
-Machine.prototype._executeRuntimeCode = function (runtimeName, code) {
+Machine.prototype._executeRuntimeCode = function (runtimeName, code, options) {
+    options = options || {};
     runtime = this.getRuntime(runtimeName);
     if (runtime) {
+        var applyOptions = function (rt) {
+            if (rt && typeof rt === "object" && "simulation_mode" in rt) {
+                rt.simulation_mode = !!options.debug;
+                if (this.status) {
+                    this.status.simulation_mode = rt.simulation_mode;
+                    this.status.simulated_inputs = rt.simulated_inputs || {};
+                }
+            }
+        }.bind(this);
+
         if (this.current_runtime == this.idle_runtime) {
             this.setRuntime(
                 runtime,
@@ -1980,11 +2003,13 @@ Machine.prototype._executeRuntimeCode = function (runtimeName, code) {
                     if (err) {
                         log.error(err);
                     } else {
+                        applyOptions(runtime);
                         runtime.executeCode(code);
                     }
                 }.bind(this)
             );
         } else {
+            applyOptions(this.current_runtime);
             this.current_runtime.executeCode(code);
         }
     }

--- a/routes/direct.js
+++ b/routes/direct.js
@@ -1,4 +1,5 @@
 var machine = require("../machine").machine;
+var log = require("../log").logger("api");
 
 /**
  * @api {post} /code Execute tool runtime code
@@ -6,6 +7,7 @@ var machine = require("../machine").machine;
  * @apiDescription Run the POSTed code using the specified runtime.
  * @apiParam {Object} runtime Name of the runtime to run the code.  Currently suppored: `g` | `sbp`
  * @apiParam {Object} cmd The actual code to run.
+ * @apiParam {Boolean} [debug] If true, run in input-simulation (debug) mode. SBP runtime only.
  * @apiError {String} status `error`
  * @apiError {Object} message Error message
  */
@@ -20,15 +22,19 @@ var code = function (req, res, next) {
         if (req.params.cmd !== undefined) {
             if (req.params.runtime !== undefined) {
                 var rt = req.params.runtime.toLowerCase().trim();
+                var debug = !!req.params.debug;
                 switch (rt) {
                     case "opensbp":
                     case "sbp":
-                        machine.sbp(req.params.cmd);
+                        machine.sbp(req.params.cmd, { debug: debug });
                         break;
 
                     case "g":
                     case "nc":
                     case "gcode":
+                        if (debug) {
+                            log.warn("debug flag ignored for gcode runtime");
+                        }
                         machine.gcode(req.params.cmd);
                         break;
 
@@ -60,6 +66,36 @@ var code = function (req, res, next) {
     res.json(answer);
 };
 
+/**
+ * @api {post} /code/sim_input Force a simulated input value (debug mode)
+ * @apiGroup Direct
+ * @apiDescription While the SBP runtime is running in debug/simulation mode,
+ *   set the value of a simulated input. IF INPUT(n) and other expression reads
+ *   of input state will see the forced value.
+ * @apiParam {Number} inp Input number (1-based, 1..12)
+ * @apiParam {Boolean} state Forced input state
+ * @apiError {String} status `error`
+ * @apiError {Object} message Error message
+ */
+// eslint-disable-next-line no-unused-vars
+var simInput = function (req, res, next) {
+    var inp = parseInt(req.params.inp, 10);
+    var state = !!req.params.state;
+    if (!Number.isFinite(inp) || inp < 1 || inp > 12) {
+        return res.json({ status: "error", message: "inp must be an integer 1..12" });
+    }
+    var rt = machine.sbp_runtime;
+    if (!rt || !rt.simulation_mode) {
+        return res.json({
+            status: "error",
+            message: "SBP runtime is not in simulation mode",
+        });
+    }
+    rt.setSimulatedInput(inp, state);
+    res.json({ status: "success", data: { inp: inp, state: state } });
+};
+
 module.exports = function (server) {
     server.post("/code", code);
+    server.post("/code/sim_input", simInput);
 };

--- a/runtime/opensbp/commands/probe.js
+++ b/runtime/opensbp/commands/probe.js
@@ -34,16 +34,15 @@ function validateProbeArgs(cmdName, args, expectedCount) {
 function probe(runtime, opts) {
     var name = "prbin";
     var input = opts.inp;
-    var input_action = config.machine.get("di" + input + "ac");
     var cmd1 = {};
     cmd1[name] = opts.inp;
+    var word;
 
     // Determine tolerance for "already at target" check based on unit system
     var tolerance = runtime.units === "mm" ? 0.125 : 0.005;
 
     // Check if we're already at (or within tolerance of) the probe target location
     var allAtTarget = true;
-    var word;
     for (word in opts.dist) {
         var currentPos = runtime[axisPosMap[word]] || 0.0;
         var targetPos = opts.dist[word];
@@ -57,6 +56,42 @@ function probe(runtime, opts) {
               (runtime.units === "mm" ? "mm" : "in") + ") so probe has no distance to travel";
     }
 
+    // Simulation/debug mode: emit a normal G1 to target instead of G38.3.
+    // The runtime watches for a rising-edge sim input on opts.inp; if it fires
+    // mid-move it captures position, feedholds, flushes the queue, and emits a
+    // corrective G1 back to the captured trip position — mimicking a real probe.
+    // If no trip happens, the move runs to completion (treated as a "miss",
+    // equivalent to a real G38.3 no-fault-on-miss probe that didn't trip).
+    if (runtime.simulation_mode) {
+        // Mirror real-probe behavior: error if the sim input is already active.
+        if (runtime.simulated_inputs && runtime.simulated_inputs[opts.inp]) {
+            throw "Input#" + opts.inp + " is already active (ON) so cannot be used for Probing request ";
+        }
+        var simCmd = ["G1"];
+        var simAxes = [];
+        for (word in opts.dist) {
+            simCmd.push(word + opts.dist[word].toFixed(5));
+            simAxes.push(word);
+        }
+        var simFeed = opts.feed * 60.0;
+        simCmd.push("F" + simFeed.toFixed(3));
+        log.info("SIM probe: emitting " + simCmd.join(" ") + " (input " + opts.inp + ")");
+        runtime.sim_probe = {
+            input: opts.inp,
+            feed: simFeed,
+            axes: simAxes,
+            phase: "probing",
+            trip_pos: null,
+        };
+        runtime.emit_gcode(simCmd.join(" "));
+        // probingPending=true defers the next stack-breaking command until STAT_STOP
+        // fires after the probe move (or after the corrective backup move on trip).
+        runtime.probingPending = true;
+        runtime.prime();
+        return;
+    }
+
+    var input_action = config.machine.get("di" + input + "ac");
     // Determine if requested probe input already has a defined action then, except for "limit", generate an error and terminate file
     switch (input_action) {
         case "stop":

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -92,6 +92,13 @@ function SBPRuntime() {
     this.driver = null;
 
     this.inManualMode = false;
+
+    // Input simulation (debug mode) — set by caller before runFile/executeCode
+    this.simulation_mode = false;
+    this.simulated_inputs = {};
+    // sim_probe is null when no probe is active. Otherwise:
+    //   { input, feed, axes, phase: "probing"|"tripping"|"returning", trip_pos }
+    this.sim_probe = null;
 }
 
 util.inherits(SBPRuntime, events.EventEmitter);
@@ -571,16 +578,54 @@ SBPRuntime.prototype._saveDriverSettings = async function (callback) {
 SBPRuntime.prototype.runFile = function (filename) {
     //log.info("####=.runFile");
     this.lastFilename = filename;
-    
+
     // Only set currentFilename if not already set (by machine._runFile)
     if (!this.currentFilename) {
         this.currentFilename = require('path').basename(filename);
     }
-    
+
     log.debug(`[Filename Tracking] runFile currentFilename: ${this.currentFilename}`);
-    
+
     var st = fs.createReadStream(filename);
     this.runStream(st);
+};
+
+// Force a simulated input value while running in debug/simulation mode.
+// IF INPUT(n) and other expression reads of %(51)..%(63) will see the forced
+// value via evaluateSystemVariable. If a sim probe is currently in flight on
+// this input, a rising-edge transition triggers a "probe trip": the in-flight
+// motion is feedheld, the queue is flushed, and a corrective G1 is emitted to
+// the position captured at click time — mimicking a real probe.
+//   inp - input number (1-based)
+//   state - boolean
+SBPRuntime.prototype.setSimulatedInput = function (inp, state) {
+    if (!this.simulation_mode) {
+        log.warn("setSimulatedInput called but runtime is not in simulation_mode");
+        return;
+    }
+    var prev = !!this.simulated_inputs[inp];
+    var next = !!state;
+    this.simulated_inputs[inp] = next;
+    log.info("SIM input " + inp + " = " + (next ? "ON" : "OFF"));
+    if (this.machine) {
+        this.machine.status.simulated_inputs = this.simulated_inputs;
+        this.machine.emit("status", this.machine.status);
+    }
+
+    // Probe trip: rising edge during a probe move on the matching input
+    if (next && !prev && this.sim_probe && this.sim_probe.phase === "probing" && this.sim_probe.input === inp) {
+        this.sim_probe.phase = "tripping";
+        this.sim_probe.trip_pos = {
+            X: this.driver.status.posx,
+            Y: this.driver.status.posy,
+            Z: this.driver.status.posz,
+            A: this.driver.status.posa,
+            B: this.driver.status.posb,
+            C: this.driver.status.posc,
+        };
+        log.info("SIM probe trip on input " + inp + " at " + JSON.stringify(this.sim_probe.trip_pos));
+        this.driver.feedHold();
+    }
 };
 
 // Simulate the provided file, returning the result as g-code string
@@ -930,8 +975,16 @@ SBPRuntime.prototype._run = function () {
                     this.probingPending = false;
                     this.probingActive = false;
                     this.probingHeld = false;
-                    this.emit_gcode('M100.1("{prbin:0}")'); // turn off probing targets
-                    this.prime();
+                    if (this.sim_probe) {
+                        // Sim probe never set prbin; just clear sim state.
+                        // Phase tells us whether this was a "miss" (probing → end of move)
+                        // or a completed trip cycle (returning → end of corrective backup).
+                        log.info("SIM probe cycle complete (phase=" + this.sim_probe.phase + ")");
+                        this.sim_probe = null;
+                    } else {
+                        this.emit_gcode('M100.1("{prbin:0}")'); // turn off probing targets
+                        this.prime();
+                    }
                     log.info("COMPLETED PENDING PROBING =(cleared)============####");
                     this._executeNext();
                     break;
@@ -945,6 +998,29 @@ SBPRuntime.prototype._run = function () {
                 break;
 
             case this.driver.STAT_HOLDING:
+                // Sim probe trip: hijack the hold sequence to flush the in-flight probe move
+                // and emit a corrective G1 back to the trip position. We bypass the normal
+                // "machine state → paused" transition entirely so the file appears to flow
+                // through naturally, like a real probe trip.
+                if (this.sim_probe && this.sim_probe.phase === "tripping") {
+                    var probeRuntime = this;
+                    log.info("SIM probe: STAT_HOLDING — flushing queue, queueing corrective backup");
+                    this.driver.queueFlush(function () {
+                        var simCmd = ["G1"];
+                        for (var i = 0; i < probeRuntime.sim_probe.axes.length; i++) {
+                            var ax = probeRuntime.sim_probe.axes[i];
+                            simCmd.push(ax + probeRuntime.sim_probe.trip_pos[ax].toFixed(5));
+                        }
+                        simCmd.push("F" + probeRuntime.sim_probe.feed.toFixed(3));
+                        log.info("SIM probe: corrective backup: " + simCmd.join(" "));
+                        probeRuntime.sim_probe.phase = "returning";
+                        probeRuntime.emit_gcode(simCmd.join(" "));
+                        probeRuntime.prime();
+                        probeRuntime.driver.resume();
+                    });
+                    return;
+                }
+
                 this.feedhold = true;
 
                 // Handle feedhold during probing - distinguish between active probe and post-completion
@@ -1294,8 +1370,20 @@ SBPRuntime.prototype._end = function (error) {
 SBPRuntime.prototype._finishEnd = function (error_msg) {
     this.resumeAllowed = true;
 
+    // End of run — clear input simulation state so the next run starts clean
+    // and the dashboard's sim input row hides.
+    if (this.simulation_mode) {
+        this.simulation_mode = false;
+        this.simulated_inputs = {};
+        this.sim_probe = null;
+        if (this.machine && this.machine.status) {
+            this.machine.status.simulation_mode = false;
+            this.machine.status.simulated_inputs = {};
+        }
+    }
+
     var self = this;
-    
+
     var doSetState = function () {
         if (self.machine && typeof self.machine.setState === 'function') {
             if (error_msg) {
@@ -2316,6 +2404,11 @@ SBPRuntime.prototype.init = function () {
     this.pending_error = null;
     this.pendingFeedhold = false;
 
+    // Reset input-simulation state on each program start. simulation_mode itself
+    // is preserved — it's set by the caller before runFile()/executeCode().
+    this.simulated_inputs = {};
+    this.sim_probe = null;
+
     if (this.transforms != null && this.transforms.level.apply === true) {
         this.leveler = new Leveler(this.transforms.level.ptDataFile);
     }
@@ -2569,6 +2662,9 @@ SBPRuntime.prototype.evaluateSystemVariable = function (v) {
         case 61:
         case 62: // End of current inputs at #12
         case 63:
+            if (this.simulation_mode) {
+                return this.simulated_inputs[n - 50] ? 1 : 0;
+            }
             return this.machine.status["in" + (n - 50)];
 
         // NOTE: More inputs are imagined here


### PR DESCRIPTION
Lets users run an SBP file in a debug/simulation mode where the 12 machine inputs can be forced from the dashboard. IF INPUT(n), %(50+n) reads, and probe commands all see the simulated values. Probe commands in sim mode emit a normal G1 toward target; if the user triggers the probe input mid-move, motion feedholds, the queue is flushed, and a corrective G1 backs the head up to the position captured at trigger time — mimicking real probe trip behavior.

Server:
- runtime/opensbp/opensbp.js: simulation_mode + simulated_inputs map on SBPRuntime; system variables %(51)–%(63) route through the simulated map when sim mode is on; setSimulatedInput method handles the input write and detects rising-edge probe trips. STAT_HOLDING bypass for sim trip flushes the queue and emits the corrective G1. STAT_STOP probe-completion path handles both miss and trip-cycle- complete cases. Sim state cleared in init() and _finishEnd.
- runtime/opensbp/commands/probe.js: sim path emits G1 instead of G38.3, sets up a sim_probe state object (input, feed, axes, phase, trip_pos), uses probingPending to defer the next file line. Mirrors real-probe rejection if the sim input is already active.
- machine.js: executeRuntimeCode/sbp() accept {debug:true}; option flows through deferred-auth path to set runtime.simulation_mode. _runFile clears simulation_mode for submitted (non-debug) jobs.
- routes/direct.js: /code accepts a debug flag; new POST /code/sim_input {inp,state} forces a simulated input.

Dashboard:
- libs/fabmoapi.js, libs/fabmo.js, dashboard.js: client-side sbpDebug() + setSimInput() with IPC handlers.
- build/index.html + static/css/style.css: input-trigger row in the footer, anchored top-left so it doesn't overlap pause/resume/quit.
- static/js/dashboard.js: renders 12 momentary push-buttons in the row when status.simulation_mode is true. mousedown/touchstart sets ON, mouseup/mouseleave/touchend sets OFF. Visual state mirrors status.simulated_inputs.
- editor.fma: new "Run in Debug Mode" menu item under Execute/Save, same dirty-state handling as Run Immediately.

Phase 2 limitations to revisit if probing is refactored:
- Sim trip relies on existing probingPending machinery to gate the next stack-breaking command on STAT_STOP.
- STAT_HOLDING handler has an early return for sim_probe.phase === "tripping"; preserve when modifying that handler.
- Trip position uses driver.status.posx/y/z at click time; small lag from G2 status reports is acceptable for sim purposes.