### PR TITLE
Fix no-motion polling loop ignoring pause/feedhold requests

### DIFF
--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2969,7 +2969,15 @@ SBPRuntime.prototype.pause = function () {
         this.machine.driver.status.stat == this.machine.driver.STAT_END ||
         this.machine.driver.status.stat == this.machine.driver.STAT_STOP
     ) {
+        // G2 is already stopped — there's no motion to feedhold against. Defer
+        // a feedhold for the next motion command (pendingFeedhold), but ALSO halt
+        // the runtime loop now: a no-motion polling loop (e.g. `IF INPUT(n) GOTO ...`)
+        // would otherwise spin forever, since pendingFeedhold only fires inside the
+        // STAT_RUNNING handler and STAT_RUNNING never arrives without motion.
         this.pendingFeedhold = true;
+        this.feedhold = true;
+        this.machine.status.inFeedHold = true;
+        this.machine.setState(this, "paused");
     } else {
         //Send feedhold to driver
         this.machine.driver.feedHold();


### PR DESCRIPTION
A tight SBP loop with no motion (e.g. `IF %(55)==1 THEN GOTO HIT / GOTO START`) leaves G2 in STAT_STOP. The deferred-feedhold branch in SBPRuntime.pause set only pendingFeedhold, which is consumed inside the STAT_RUNNING handler — but motion never starts, so the runtime spins forever and the UI stays stuck in "running" with no way to recover except quit.

Also set feedhold=true (so _executeNext bails on the next iteration) and transition machine state to "paused" (so resume/quit become reachable from the dashboard).