### PR TITLE
Fix SBP duplicate-label crash from leaked parser streams

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -1323,6 +1323,14 @@ Machine.prototype.getGCodeForFile = function (filename, callback) {
 Machine.prototype._runFile = function (filename) {
     var ext = path.extname(filename).toLowerCase();
 
+    // Defensive: clear any stale per-job state on the SBP runtime singleton
+    // before starting a new top-level job. A prior job that ended abnormally
+    // (E-stop, motor fault, driver disconnect) can leave file_stack/program
+    // populated, which would contaminate this run's _analyzeLabels.
+    if (ext === ".sbp" && this.sbp_runtime && typeof this.sbp_runtime._resetForTopLevelRun === "function") {
+        this.sbp_runtime._resetForTopLevelRun();
+    }
+
     // Save pre-run state for restoration after the run
     this._preRunUnits = config.machine.get("units");
     

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -368,6 +368,14 @@ SBPRuntime.prototype.runStream = function (text_stream) {
     this._endCalled = false; // Reset for new run so errors before _run() aren't suppressed
     //log.info("####=.runStream");
     try {
+        // Tear down any prior parser/input stream still bound to this runtime.
+        // Without this, pending `data` events from an interrupted prior parse
+        // can fire AFTER we reset this.program=[] and push leaked entries into
+        // the new program — yielding bogus duplicate-label errors. The data
+        // handler captures `this`, not `this.program`, so the leak follows
+        // whatever this.program currently points at.
+        this._destroyActiveParse();
+
         // Initialize the program
         this.pc = 0;
         this.program = [];
@@ -375,6 +383,8 @@ SBPRuntime.prototype.runStream = function (text_stream) {
         // the entire body of data before we can continue processing the file.
         // That's why the business end of this function occurs in the 'end' handler
         var st = parser.parseStream(text_stream);
+        this._activeInputStream = text_stream;
+        this._activeParser = st;
 
         // The stream produced by parser.parseStream produces fully parsed program lines,
         // which can just be added to the program as they come in.
@@ -390,6 +400,12 @@ SBPRuntime.prototype.runStream = function (text_stream) {
             "end",
             function () {
                 try {
+                    // Clear active-parse references — this parser is done and
+                    // any further events are spurious.
+                    if (this._activeParser === st) {
+                        this._activeParser = null;
+                        this._activeInputStream = null;
+                    }
                     log.tock("Parse file");
 
                     // The machine status `nb_lines` indicates the total number of lines in the currently running file
@@ -416,6 +432,11 @@ SBPRuntime.prototype.runStream = function (text_stream) {
                     // This step unfortunately requires the whole file
                     this._analyzeLabels();
                     log.tock("Labels analyzed...");
+                    var labelCount = Object.keys(this.label_index || {}).length;
+                    log.info("[macro-trace] LOADED depth=" + this.file_stack.length +
+                             "  filename=" + this.currentFilename +
+                             "  program.length=" + this.program.length +
+                             "  labels=" + labelCount);
 
                     // Check all the GOTO/GOSUBs against the label table
                     this._analyzeGOTOs();
@@ -570,6 +591,60 @@ SBPRuntime.prototype._saveDriverSettings = async function (callback) {
         log.error(error);
         callback(error);
     }
+};
+
+// Tear down any in-flight parser pipeline bound to this runtime. After an
+// abnormal end (STOP/motor-fault/driver-disconnect), pending `data` events
+// from the prior parse can still fire AFTER we reset this.program — pushing
+// leaked entries into the new array and yielding spurious duplicate-label
+// errors. The runStream `data` handler captures `this` (not this.program),
+// so the leak target is whatever this.program currently points at.
+SBPRuntime.prototype._destroyActiveParse = function () {
+    if (this._activeParser) {
+        try { this._activeParser.removeAllListeners("data"); } catch (e) { /* ignore */ }
+        try { this._activeParser.removeAllListeners("end"); } catch (e) { /* ignore */ }
+        try { this._activeParser.destroy(); } catch (e) { /* ignore */ }
+        this._activeParser = null;
+        log.info("[macro-trace] destroyed in-flight parser stream");
+    }
+    if (this._activeInputStream) {
+        try { this._activeInputStream.destroy(); } catch (e) { /* ignore */ }
+        this._activeInputStream = null;
+    }
+};
+
+// Defensive reset for the singleton runtime at the top of a new top-level job.
+// A prior job that ended abnormally (E-stop, motor fault, driver disconnect)
+// can leave file_stack frames, label_index, pc, etc. populated. The next run
+// would then POP into a stale frame and contaminate this.program. Logs what
+// it found so we can confirm if/when this guard is masking a real leak.
+SBPRuntime.prototype._resetForTopLevelRun = function () {
+    // Kill any leaked parser stream first — that's the bug mechanism behind
+    // the duplicate-label crash; state cleanup alone doesn't address it.
+    this._destroyActiveParse();
+    var stale = [];
+    if (this.file_stack && this.file_stack.length) stale.push("file_stack[" + this.file_stack.length + "]");
+    if (this.stack && this.stack.length) stale.push("stack[" + this.stack.length + "]");
+    if (this.program && this.program.length) stale.push("program[" + this.program.length + "]");
+    if (this.label_index && Object.keys(this.label_index).length) stale.push("label_index[" + Object.keys(this.label_index).length + "]");
+    if (this.pc) stale.push("pc=" + this.pc);
+    if (this.currentFilename) stale.push("currentFilename=" + this.currentFilename);
+    if (stale.length) {
+        log.warn("[macro-trace] FRESH-RUN found stale state: " + stale.join(", "));
+    } else {
+        log.info("[macro-trace] FRESH-RUN clean state");
+    }
+    this.file_stack = [];
+    this.stack = [];
+    this.program = [];
+    this.label_index = {};
+    this.pc = 0;
+    this.currentFilename = null;
+    this.paused = false;
+    this.feedhold = false;
+    this.resumeAllowed = true;
+    this.end_message = undefined;
+    this.quit_pending = false;
 };
 
 // Run a file on disk.
@@ -2495,15 +2570,65 @@ SBPRuntime.prototype._analyzeLabels = function () {
             switch (line.type) {
                 case "label":
                     if (line.value in this.label_index) {
-                        // Report ACTUAL line numbers (not +1)
                         const firstLine = this.label_index[line.value] + 1;
                         const duplicateLine = i + 1;
+                        this._dumpDuplicateLabelDiagnostics(line.value, this.label_index[line.value], i);
                         throw new Error(`@line-${firstLine} and @line-${duplicateLine}: Duplicate labels "${line.value}"`);
                     }
                     this.label_index[line.value] = i;
                     break;
             }
         }
+    }
+};
+
+// Diagnostic dump fired only when _analyzeLabels detects a duplicate.
+// Logs runtime context, file_stack, every label in this.program, and the entries
+// surrounding both occurrences — enough to reconstruct what this.program actually
+// contains when the duplicate fires.
+SBPRuntime.prototype._dumpDuplicateLabelDiagnostics = function (label, firstIdx, secondIdx) {
+    try {
+        var entryBrief = function (entry) {
+            if (!entry) return "<null>";
+            var t = entry.type || "?";
+            if (t === "label") return "label:" + entry.value;
+            if (t === "goto" || t === "gosub") return t + ":" + entry.label;
+            if (t === "custom") return "custom:CN" + entry.index;
+            if (t === "cmd") return "cmd:" + entry.cmd + (entry.args && entry.args.length ? "(" + entry.args.length + ")" : "");
+            if (t === "gcode") return "gcode:" + (entry.gcode || "").slice(0, 30);
+            return t;
+        };
+        log.error("=== DUPLICATE LABEL DIAGNOSTICS ===");
+        log.error("label='" + label + "'  firstIdx=" + firstIdx + "  secondIdx=" + secondIdx +
+                  "  gap=" + (secondIdx - firstIdx));
+        log.error("currentFilename=" + this.currentFilename);
+        log.error("program.length=" + this.program.length);
+        log.error("file_stack depth=" + this.file_stack.length);
+        for (var f = 0; f < this.file_stack.length; f++) {
+            var fr = this.file_stack[f];
+            log.error("  frame[" + f + "] filename=" + fr.filename +
+                      "  program.length=" + (fr.program ? fr.program.length : "<none>"));
+        }
+        var allLabels = [];
+        for (var j = 0; j < this.program.length; j++) {
+            var e = this.program[j];
+            if (e && e.type === "label") allLabels.push(j + ":" + e.value);
+        }
+        log.error("all labels in this.program (" + allLabels.length + "): " + allLabels.join(", "));
+        var dumpRange = function (centerIdx, label) {
+            var lo = Math.max(0, centerIdx - 8);
+            var hi = Math.min(this.program.length, centerIdx + 9);
+            log.error("--- entries around " + label + " (idx " + centerIdx + ") ---");
+            for (var k = lo; k < hi; k++) {
+                var marker = k === centerIdx ? " >>> " : "     ";
+                log.error(marker + k + "  " + entryBrief(this.program[k]));
+            }
+        }.bind(this);
+        dumpRange(firstIdx, "first");
+        dumpRange(secondIdx, "second");
+        log.error("=== END DUPLICATE LABEL DIAGNOSTICS ===");
+    } catch (dumpErr) {
+        log.error("Failed to dump duplicate-label diagnostics: " + dumpErr);
     }
 };
 
@@ -2847,11 +2972,17 @@ SBPRuntime.prototype._pushFileStack = function () {
     frame.label_index = this.label_index;
     frame.filename = this.currentFilename;  // filename tracking for reporting
     this.file_stack.push(frame);
+    log.info("[macro-trace] PUSH depth=" + this.file_stack.length +
+             "  saved filename=" + frame.filename +
+             "  saved program.length=" + (frame.program ? frame.program.length : 0) +
+             "  saved pc=" + frame.pc);
 };
 
 // Retrieve the execution frame on top of this.file_stack and restore the program context from it
 // The program context here means things like which coordinate system, speeds, the current PC, etc.
 SBPRuntime.prototype._popFileStack = function () {
+    var leavingFilename = this.currentFilename;
+    var leavingLength = this.program ? this.program.length : 0;
     var frame = this.file_stack.pop();
     this.movespeed_xy = frame.movespeed_xy;
     this.movespeed_z = frame.movespeed_z;
@@ -2863,6 +2994,10 @@ SBPRuntime.prototype._popFileStack = function () {
     this.label_index = frame.label_index;
     this.end_message = frame.end_message;
     this.currentFilename = frame.filename;
+    log.info("[macro-trace] POP  depth=" + this.file_stack.length +
+             "  leaving=" + leavingFilename + " (program.length=" + leavingLength + ")" +
+             "  restored=" + this.currentFilename + " (program.length=" + this.program.length +
+             ", pc=" + this.pc + ")");
 };    
 
 // Emit a g-code into the stream of running codes

--- a/runtime/opensbp/test_dupe_repro.js
+++ b/runtime/opensbp/test_dupe_repro.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Reproduces the customer's "Duplicate labels RUN_MANUAL" error deterministically
+// by leveraging the parseStream-leak mechanism proven in test_parsestream_race.js.
+//
+// Scenario: prior job was interrupted while parsing macro 23. When the new job
+// later calls C23, the stale parser's pending events fire into macro 23's
+// fresh program array — adding a second copy of RUN_MANUAL alongside the
+// freshly-parsed one. _analyzeLabels then throws.
+//
+// We then show two fixes:
+//   (a) the current _resetForTopLevelRun() guard — does NOT address this
+//   (b) explicitly destroying the prior parser stream — DOES address it
+
+var SBPRuntime = require("./opensbp").SBPRuntime;
+var parser = require("./parser");
+var stream = require("stream");
+
+function macro23Src() {
+    var lines = ["MS,3,3", "JS,10,10", "RUN_MANUAL:"];
+    for (var i = 0; i < 18; i++) lines.push("MZ,-0.1");
+    return lines.join("\n") + "\n";
+}
+
+function runScenario(label, applyFix) {
+    console.log("\n========== " + label + " ==========");
+    var rt = new SBPRuntime();
+
+    // STAGE 1: Prior job is parsing macro 23. Interrupted mid-parse.
+    rt.program = [];
+    rt.currentFilename = "C23 (PROBE_HEAD)";
+    var oldInput = new stream.PassThrough();
+    var oldParser = parser.parseStream(oldInput);
+    var oldHandler = function (data) { rt.program.push(data); }.bind(rt);
+    oldParser.on("data", oldHandler);
+    oldParser.on("error", function () {});
+
+    // Write macro 23 — but never end the input. STOP fires here.
+    oldInput.write(macro23Src());
+
+    // STAGE 2: Customer's STOP/abort path. Maybe _end runs (clearing some state)
+    // but the parser stream isn't explicitly destroyed.
+    if (applyFix === "guard-state-only") {
+        // What the guard used to do — clear state but leave the parser alive.
+        rt.file_stack = [];
+        rt.stack = [];
+        rt.program = [];
+        rt.label_index = {};
+        rt.pc = 0;
+        rt.currentFilename = null;
+    } else if (applyFix === "guard-current") {
+        // The current production guard, which now also destroys the parser.
+        // BUT: in real code, the parser is tracked via _activeParser, set by
+        // runStream. Here we manually wire it so the helper finds it.
+        rt._activeInputStream = oldInput;
+        rt._activeParser = oldParser;
+        rt._resetForTopLevelRun();
+    }
+    // For "no-fix" we do nothing.
+
+    // STAGE 3: New job runs. It eventually calls C23. runStream loads macro 23
+    // fresh into rt.program. The OLD parser's pending events fire concurrently.
+    rt.program = [];
+    rt.currentFilename = "C23 (PROBE_HEAD)";
+    var newInput = new stream.PassThrough();
+    var newParser = parser.parseStream(newInput);
+    newParser.on("data", function (data) { rt.program.push(data); }.bind(rt));
+    newParser.on("error", function () {});
+    newInput.write(macro23Src());
+    newInput.end();
+    oldInput.end();   // let any stale events drain
+
+    setTimeout(function () {
+        console.log("After both parses settle:");
+        console.log("  rt.program.length = " + rt.program.length + " (expected 21 if clean)");
+        var labels = [];
+        for (var i = 0; i < rt.program.length; i++) {
+            if (rt.program[i] && rt.program[i].type === "label" && rt.program[i].value === "RUN_MANUAL") {
+                labels.push(i);
+            }
+        }
+        console.log("  RUN_MANUAL indices = " + JSON.stringify(labels));
+        try {
+            rt._analyzeLabels();
+            console.log("  _analyzeLabels: PASSED");
+        } catch (e) {
+            console.log("  _analyzeLabels: THREW → [" + rt.currentFilename + "] " + e.message);
+        }
+    }, 50);
+}
+
+// Sequence three runs — each independent, results print as they complete
+runScenario("Scenario 1: NO FIX (baseline)",                            null);
+setTimeout(function () {
+    runScenario("Scenario 2: state cleanup only (insufficient)",        "guard-state-only");
+}, 200);
+setTimeout(function () {
+    runScenario("Scenario 3: production guard (state + parser kill)",   "guard-current");
+}, 400);


### PR DESCRIPTION
After an abnormal job end (E-stop, motor fault, driver disconnect), the prior runStream parser pipeline could remain alive with pending data events. Because the data handler captures `this` (not `this.program`), those deferred events would push parsed entries from the prior file into whatever this.program pointed at when they fired — typically the next job's freshly-reset program array. _analyzeLabels would then see the same label twice and throw

  [<macro>] @line-N and @line-N+gap: Duplicate labels "<name>"

where `gap` equals the prior file's program length. Reported in the field after E-stop recovery on jobs that nest macro calls.

Fix: track the active parser/input stream on the runtime and tear them down before binding new handlers in runStream. Also expose _resetForTopLevelRun() and call it from machine._runFile so the next top-level job starts from a guaranteed-clean state, with diagnostic logs when stale state is found.

test_dupe_repro.js reproduces the bug deterministically in three scenarios (no fix / state cleanup only / production guard) and verifies the fix.