### PR TITLE
Add per-job repeat mode toggle to Job Manager

### DIFF
--- a/dashboard/apps/job_manager.fma/css/style.css
+++ b/dashboard/apps/job_manager.fma/css/style.css
@@ -1051,3 +1051,37 @@ table {
   z-index: 10;
 }
 
+
+/* Repeat-mode toggle button on the next-in-queue card.
+   Sits just below the play button (bottom-right of the radial), fully clear
+   of the 100x100 play circle. Click toggles persistent server-side repeat. */
+.repeat-button {
+  position: absolute;
+  top: 78px;
+  right: 34px;
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  color: #888;
+  cursor: pointer;
+  border-radius: 50%;
+  z-index: 51;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.repeat-button i {
+  font-size: 20px;
+}
+
+.repeat-button:hover {
+  color: #444;
+}
+
+.repeat-button.on {
+  color: #32B433;
+}
+
+.repeat-button.on:hover {
+  color: #1f8a1f;
+}

--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -170,7 +170,7 @@ function createRecentMenu(id) {
 }
 
 function makeActions() {
-  var actions = '<div> <div class="small-2 medium-4 columns play-button" style="text-align:right;"> <div class="radial_progress"> <div class="percent_circle"> <div class="mask full"><div class="fill"></div></div><div class="mask half"><div class="fill"></div><div class="fill fix"> </div> </div> <div class="shadow"> </div> </div> <div class="inset"> <div id="run-next" class="play"><i class="fa fa-play" title="Start/Resume"></i></div> </div></div></div></div><div class="small-8 medium-12 icon-row" sortable="false"><div class="medium-1 small-2 columns"><a class="preview" title="Preview Job"><img  class="svg" src="css/images/visible9.svg"></a></div><div class="medium-1 small-2 columns"><a class="edit" title="Edit Job"><img class="svg" src="images/edit_icon.png"></a></div><div class="medium-1 small-2 columns"><a class="download" title="Download Job as CNC File"><img  class="svg" src="css/images/download151.svg"></a></div><div class="medium-1 small-2 columns"><a class="cancel" title="Cancel Job"><img  class="svg" src="css/images/recycling10.svg"></a></div><div class="sm-1 columns"></div></div><div class="row"></div><div class="job-lights-container"><div class="job-status-light one off"><div class="job-status-indicator"></div></div><div class="job-status-light two off"><div class="job-status-indicator"></div></div><div class="job-status-light three off"><div class="job-status-indicator"></div></div></div>'
+  var actions = '<div> <div class="small-2 medium-4 columns play-button" style="text-align:right;"> <div class="radial_progress"> <div class="percent_circle"> <div class="mask full"><div class="fill"></div></div><div class="mask half"><div class="fill"></div><div class="fill fix"> </div> </div> <div class="shadow"> </div> </div> <div class="inset"> <div id="run-next" class="play"><i class="fa fa-play" title="Start/Resume"></i></div> </div></div><a class="repeat-button" title="Toggle Repeat (re-run this job when it finishes)"><i class="fa fa-repeat"></i></a></div></div><div class="small-8 medium-12 icon-row" sortable="false"><div class="medium-1 small-2 columns"><a class="preview" title="Preview Job"><img  class="svg" src="css/images/visible9.svg"></a></div><div class="medium-1 small-2 columns"><a class="edit" title="Edit Job"><img class="svg" src="images/edit_icon.png"></a></div><div class="medium-1 small-2 columns"><a class="download" title="Download Job as CNC File"><img  class="svg" src="css/images/download151.svg"></a></div><div class="medium-1 small-2 columns"><a class="cancel" title="Cancel Job"><img  class="svg" src="css/images/recycling10.svg"></a></div><div class="sm-1 columns"></div></div><div class="row"></div><div class="job-lights-container"><div class="job-status-light one off"><div class="job-status-indicator"></div></div><div class="job-status-light two off"><div class="job-status-indicator"></div></div><div class="job-status-light three off"><div class="job-status-indicator"></div></div></div>'
   return actions;
 }
 
@@ -292,6 +292,14 @@ function setFirstCard(job) {
   $('.preview').data('id', firstId);
   $('.download').data('id', firstId);
   $('.edit').data('id', firstId);
+  $('.repeat-button').data('id', firstId);
+
+  // Reflect persisted repeat state on the toggle button
+  if (job && job.repeat) {
+    $('.repeat-button').addClass('on');
+  } else {
+    $('.repeat-button').removeClass('on');
+  }
 
   // Pre-flight soft-limit warning. analyzeJobBounds runs server-side after
   // submit and tags `softLimitCheck.exceeds` on out-of-envelope jobs; the
@@ -844,7 +852,7 @@ var sortable = Sortable.create(el, {
   clickDelay: 0,
   touchDelay: 100,
   animation: 150,
-  filter: ".cancel, .preview, .edit, .download, .play, .previewJob, .editJob, .downloadJob, .deleteJob, .restartFromLine, .ellipses",
+  filter: ".cancel, .preview, .edit, .download, .play, .repeat-button, .previewJob, .editJob, .downloadJob, .deleteJob, .restartFromLine, .ellipses",
   onStart: function(evt) {
     var remove = document.getElementById('actions');
     remove.parentNode.removeChild(remove);
@@ -916,6 +924,26 @@ var sortable = Sortable.create(el, {
 });
 
 var current_job_id = 0;
+
+function bindRepeatToggle() {
+  $('#queue_table').on('click touchstart', '.repeat-button', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    var jobid = $(this).data('id') || $(this).closest('.job_item').attr('id');
+    if (!jobid) return;
+    // Optimistic UI flip; server response is authoritative and will be
+    // reflected on the next queue refresh.
+    var willBeOn = !$(this).hasClass('on');
+    $(this).toggleClass('on', willBeOn);
+    fabmo.setJobRepeat(jobid, willBeOn, function(err) {
+      if (err) {
+        fabmo.notify('error', err);
+        // Roll back the optimistic flip
+        $('.repeat-button').toggleClass('on', !willBeOn);
+      }
+    });
+  });
+}
 
 function runNext() {
   $('#queue_table').on('click touchstart', '.play', function(e) {
@@ -1162,6 +1190,7 @@ $(document).ready(function() {
 
     setupDropTarget();
     runNext();
+    bindRepeatToggle();
 
     ////## this did not fix issue with another client
     ////## TODO // look for some sort of change 

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -421,6 +421,13 @@ define(function (require) {
         );
 
         this._registerHandler(
+            "setJobRepeat",
+            function (data, callback) {
+                this.engine.setJobRepeat(data.id, data.repeat, callback);
+            }.bind(this)
+        );
+
+        this._registerHandler(
             "deleteJob",
             function (id, callback) {
                 this.engine.deleteJob(

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -764,6 +764,10 @@
         this._call("resubmitJob", args, callback);
     };
 
+    FabMoDashboard.prototype.setJobRepeat = function (id, repeat, callback) {
+        this._call("setJobRepeat", { id: id, repeat: !!repeat }, callback);
+    };
+
     /**
      * Delete a job (cancels if running, sends to trash otherwise.)
      *

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -377,6 +377,10 @@
         this._post("/job/" + id, {}, callback, callback);
     };
 
+    FabMoAPI.prototype.setJobRepeat = function (id, repeat, callback) {
+        this._post("/job/" + id + "/repeat", { repeat: !!repeat }, callback, callback);
+    };
+
     FabMoAPI.prototype.updateOrder = function (data, callback) {
         this._patch("/job/" + data.id, data, callback, callback);
         this.emit("change", "jobs");

--- a/db.js
+++ b/db.js
@@ -65,14 +65,18 @@ var Job = function (options) {
     this.nb_lines = null;
     this.state = "pending";
     this.order = options.order || null;
+    this.repeat = !!options.repeat;
 };
 
 // Clone a job.  Used for re-running files, usually.
+// The `repeat` flag is carried into the clone so a repeating job keeps repeating
+// across the clone-on-finish cycle.
 Job.prototype.clone = function (callback) {
     var job = new Job({
         file_id: this.file_id,
         name: this.name,
         description: this.description,
+        repeat: this.repeat,
     });
     job.save(callback);
 };
@@ -95,15 +99,40 @@ Job.prototype.start = function (callback) {
 
 Job.prototype.finish = function (callback) {
     log.info("Finishing job id " + this._id ? this._id : "<volatile job>");
-    this.state = "finished";
+    // If a quit/cancel was already pending when finish() was called, treat the
+    // job as user-cancelled instead — so repeat mode doesn't auto-restart what
+    // was effectively an abort. Note: state save() deletes pending_cancel.
+    var wasCancelled = !!this.pending_cancel;
+    this.state = wasCancelled ? "cancelled" : "finished";
     this.finished_at = Date.now();
-    this.save(callback);
+    if (wasCancelled) this.repeat = false;
+    var that = this;
+    this.save(function (err, saved) {
+        if (callback) callback(err, saved);
+        if (err || !that.repeat) return;
+        // Repeat mode: clone the just-finished job back onto the queue and
+        // auto-start. Deferred so the runtime can complete its idle transition
+        // before we kick off the next run.
+        setImmediate(function () {
+            that.clone(function (cloneErr) {
+                if (cloneErr) {
+                    return log.error("Repeat clone failed: " + cloneErr);
+                }
+                var machine = require("./machine").machine;
+                if (!machine) return;
+                machine._runNextJob(true, function (runErr) {
+                    if (runErr) log.error("Repeat auto-restart failed: " + runErr);
+                });
+            });
+        });
+    });
 };
 
 Job.prototype.fail = function (callback) {
     log.info("Failing job id " + (this._id ? this._id : "<volatile job>"));
     this.state = "failed";
     this.finished_at = Date.now();
+    this.repeat = false; // failure clears repeat so a broken job doesn't loop
     this.save(callback);
 };
 
@@ -112,6 +141,7 @@ Job.prototype.cancel = function (callback) {
         log.debug("Cancelling running job id " + this._id);
         this.state = "cancelled";
         this.finished_at = Date.now();
+        this.repeat = false; // user-cancel clears repeat
         this.save(callback);
     } else {
         setImmediate(callback, new Error("Cannot cancel a job that is " + this.state));

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -514,15 +514,48 @@ var getJobGCode = function (req, res, next) {
     });
 };
 
+// eslint-disable-next-line no-unused-vars
+var setJobRepeat = function (req, res, next) {
+    var desired = req.body && typeof req.body.repeat !== "undefined" ? !!req.body.repeat : null;
+    db.Job.getById(req.params.id, function (err, job) {
+        if (err || !job) {
+            return res.json({ status: "error", message: err || "Job not found" });
+        }
+        job.repeat = desired === null ? !job.repeat : desired;
+        job.save(function (saveErr, saved) {
+            if (saveErr) {
+                return res.json({ status: "error", message: saveErr });
+            }
+            // If the toggled job is currently running, the machine holds its
+            // own in-memory copy loaded at job start. Mirror the change there
+            // so a mid-run toggle takes effect when finish() decides whether
+            // to auto-restart (and so finish()'s save doesn't overwrite the
+            // toggled DB value with the stale in-memory one).
+            if (
+                machine &&
+                machine.status &&
+                machine.status.job &&
+                String(machine.status.job._id) === String(saved._id)
+            ) {
+                machine.status.job.repeat = saved.repeat;
+            }
+            res.json({ status: "success", data: { job: saved } });
+        });
+    });
+};
+
 module.exports = function (server) {
     server.post("/job", submitJob);
     server.get("/jobs", getAllJobs);
     server.get("/job/:id", getJobById);
     server.del("/job/:id", cancelJob);
     server.patch("/job/:id", updateOrder);
-    server.post("/job/:id", resubmitJob);
+    // More-specific :id sub-paths must register before the bare /:id route so
+    // restify matches them first.
+    server.post("/job/:id/repeat", setJobRepeat);
     server.get("/job/:id/file", getJobFile);
     server.get("/job/:id/gcode", getJobGCode);
+    server.post("/job/:id", resubmitJob);
     //server.get('/job/:id/thumbnail', getThumbnailImage);
 
     server.get("/jobs/queue", getQueue);

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1312,18 +1312,26 @@ SBPRuntime.prototype._finishEnd = function (error_msg) {
     if (this.machine && this.machine.status.job) {
         var job = this.machine.status.job;
         this.machine.status.job = null;
-        // job.finish() returns a Promise — chain it without async
-        var finishResult = job.finish();
-        if (finishResult && typeof finishResult.then === 'function') {
-            finishResult.then(
-                function () { doSetState(); },
-                function (err) {
-                    log.error("Error finishing job: " + err);
-                    doSetState();
-                }
-            );
-        } else {
+        var done = function (err) {
+            if (err) log.error("Error finalizing job: " + err);
             doSetState();
+        };
+        // If the user quit/cancelled (or the job errored), record it as
+        // cancelled/failed — not finished. Otherwise auto-restart logic
+        // attached to a clean finish (e.g. repeat mode) would fire on what
+        // was effectively an abort.
+        if (job.pending_cancel) {
+            job.cancel(done);
+        } else if (error_msg) {
+            job.fail(done);
+        } else {
+            // finish() returns a Promise — chain it without async
+            var finishResult = job.finish();
+            if (finishResult && typeof finishResult.then === 'function') {
+                finishResult.then(function () { doSetState(); }, done);
+            } else {
+                doSetState();
+            }
         }
     } else {
         doSetState();


### PR DESCRIPTION
Adds a repeat button next to the play button on the running/next-in-queue card. When enabled, the job re-clones onto the queue and auto-starts as soon as it finishes naturally, so an operator can run the same file in a continuous loop without touching the dashboard between cycles.

Repeat is a server-side flag on the Job document so the state survives page reloads and is the same across clients. Quit/cancel/fail clears the flag (no zombie loops on aborted work), and a mid-run toggle is mirrored to the machine's in-memory copy of the job so the change takes effect on the very next completion. The SBP runtime's job-end path also gained the quit/error branch that the gcode runtime already had — without it, a quit during an SBP job came back through finish() and would have triggered an unwanted auto-restart.