### PR TITLE
Add user-default snapshots, transparent recovery, /opt-loss resilience

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -38,6 +38,7 @@ var PLATFORM = require("process").platform;
 var log = require("../log").logger("config");
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
+var recoveryLog = require("./recovery_log");
 
 // Config is the superclass from which all configuration objects descend
 //   config_name - All configuration objects have a name, which among other things,
@@ -264,6 +265,39 @@ Config.prototype.load = function (filename, callback) {
         });
     };
 
+    // Try to load this config from the user's blessed snapshot. Slots
+    // into the recovery chain between the auto-backup mirror and the
+    // working/shipped profiles, so a customer's tuned baseline takes
+    // precedence over generic profile defaults when corruption hits.
+    // snapshots.js is required lazily here to avoid a circular dep
+    // (snapshots -> machine -> config).
+    const loadFromUserSnapshot = (next) => {
+        if (skipRecovery) {
+            log.info("Skipping user-snapshot recovery due to auto-profile system");
+            return next(new Error("User-snapshot recovery skipped due to auto-profile"));
+        }
+        var snapshots;
+        try {
+            snapshots = require("../snapshots");
+        } catch (e) {
+            return next(new Error("snapshots module unavailable: " + e.message));
+        }
+        var defaultName = snapshots.getDefault();
+        if (!defaultName) {
+            return next(new Error("No user-default snapshot set"));
+        }
+        var snapshotFile = path.join(
+            snapshots.snapshotPath(defaultName),
+            "config",
+            path.basename(filename)
+        );
+        if (!fs.existsSync(snapshotFile)) {
+            return next(new Error("User-default snapshot has no " + path.basename(filename)));
+        }
+        log.info(`Attempting to load from user-default snapshot '${defaultName}': ${snapshotFile}`);
+        tryLoadFile(snapshotFile, next);
+    };
+
     const loadFromWorkingProfile = (next) => {
         if (skipRecovery) {
             log.info("Skipping working profile recovery due to auto-profile system");
@@ -350,45 +384,89 @@ Config.prototype.load = function (filename, callback) {
         if (err) {
             log.warn(`Failed to load config file: ${filename}, trying backup.`);
 
-            // FIXED: Try each recovery method in sequence, stopping on first success
-            const tryRecoveryMethods = () => {
-                // Method 1: Try backup first
+            // Capture a copy of the source file for post-mortem analysis.
+            // Only meaningful when we're actually entering the recovery
+            // chain (i.e. not skipRecovery, which is the auto-profile path).
+            var corruptCopyPath = null;
+            var recordRecovery = function (recoveredFrom, finalError) {
+                if (skipRecovery) {
+                    return;
+                }
+                recoveryLog.record({
+                    config: path.basename(filename),
+                    source_path: filename,
+                    error: err && err.message ? err.message : String(err),
+                    recovered_from: recoveredFrom,
+                    final_error:
+                        finalError && finalError.message
+                            ? finalError.message
+                            : finalError || null,
+                    corrupt_copy: corruptCopyPath,
+                });
+            };
+
+            const beginRecovery = () => {
+                // Try each recovery method in sequence, stopping on first success.
+                // Order: live backup mirror -> user-default snapshot -> working
+                // profile -> shipped profile. The user-default snapshot is
+                // their blessed baseline, so it ranks above the generic
+                // profile defaults.
                 loadFromBackup((backupErr) => {
                     if (!backupErr) {
                         log.info("Successfully loaded from backup - stopping recovery chain");
                         this._loaded = true;
+                        recordRecovery("backup", null);
                         return callback(null, this._cache);
                     }
-                    
-                    log.debug("Backup recovery failed, trying working profile");
-                    
-                    // Method 2: Try working profile 
-                    loadFromWorkingProfile((workingErr) => {
-                        if (!workingErr) {
-                            log.info("Successfully loaded from working profile - stopping recovery chain");
+
+                    log.debug("Backup recovery failed, trying user-default snapshot");
+
+                    loadFromUserSnapshot((snapErr) => {
+                        if (!snapErr) {
+                            log.info("Successfully loaded from user-default snapshot - stopping recovery chain");
                             this._loaded = true;
+                            recordRecovery("user_default_snapshot", null);
                             return callback(null, this._cache);
                         }
-                        
-                        log.debug("Working profile recovery failed, trying original profile");
-                        
-                        // Method 3: Try original profile (final fallback)
-                        loadFromOriginalProfile((originalErr) => {
-                            if (!originalErr) {
-                                log.info("Successfully loaded from original profile");
+
+                        log.debug("User-snapshot recovery failed, trying working profile");
+
+                        loadFromWorkingProfile((workingErr) => {
+                            if (!workingErr) {
+                                log.info("Successfully loaded from working profile - stopping recovery chain");
                                 this._loaded = true;
+                                recordRecovery("working_profile", null);
                                 return callback(null, this._cache);
-                            } else {
-                                log.warn(`Failed to load configuration from all sources: ${originalErr.message}`);
-                                return callback(originalErr);
                             }
+
+                            log.debug("Working profile recovery failed, trying original profile");
+
+                            loadFromOriginalProfile((originalErr) => {
+                                if (!originalErr) {
+                                    log.info("Successfully loaded from original profile");
+                                    this._loaded = true;
+                                    recordRecovery("original_profile", null);
+                                    return callback(null, this._cache);
+                                } else {
+                                    log.warn(`Failed to load configuration from all sources: ${originalErr.message}`);
+                                    recordRecovery("failed", originalErr);
+                                    return callback(originalErr);
+                                }
+                            });
                         });
                     });
                 });
             };
-            
-            tryRecoveryMethods();
-            
+
+            if (skipRecovery) {
+                beginRecovery();
+            } else {
+                recoveryLog.saveCorruptCopy(filename, function (savedPath) {
+                    corruptCopyPath = savedPath;
+                    beginRecovery();
+                });
+            }
+
         } else {
             this._loaded = true;
             callback(null, this._cache);
@@ -479,7 +557,16 @@ Config.prototype.save = function (callback) {
                                         }
                                         fs.closeSync(fd); // no error reporting
                                         log.debug("  fsync done " + config_file);
-                                        callback(err);
+                                        // Mirror the just-saved file to the backup
+                                        // directory synchronously with this save so
+                                        // the backup never drifts. Mirror errors are
+                                        // logged but do not fail the save itself.
+                                        if (err) {
+                                            return callback(err);
+                                        }
+                                        mirrorConfigToBackup(config_file, function () {
+                                            callback(null);
+                                        });
                                     }.bind(this)
                                 );
                             }
@@ -492,6 +579,110 @@ Config.prototype.save = function (callback) {
         setImmediate(callback);
     }
 };
+
+// Mirror a just-saved config file to the backup mirror and the rotating
+// history. We validate by re-parsing the file we wrote, then atomically
+// write to /opt/fabmo_backup/config/<name>.json (write tmp + rename), and
+// append a timestamped copy under /opt/fabmo_backup/config_history/<name>/.
+// All errors are logged and swallowed — failure to mirror must not break
+// the primary save.
+var BACKUP_CONFIG_DIR = "/opt/fabmo_backup/config";
+var BACKUP_HISTORY_DIR = "/opt/fabmo_backup/config_history";
+var HISTORY_KEEP = 10;
+
+function mirrorConfigToBackup(savedFile, callback) {
+    fs.readFile(savedFile, "utf8", function (err, raw) {
+        if (err) {
+            log.warn("Mirror skipped, could not re-read saved file: " + err.message);
+            return callback();
+        }
+        try {
+            JSON.parse(raw);
+        } catch (e) {
+            log.warn("Mirror skipped, saved file is not valid JSON: " + e.message);
+            return callback();
+        }
+        var basename = path.basename(savedFile);
+        var mirrorPath = path.join(BACKUP_CONFIG_DIR, basename);
+        var tmpPath = mirrorPath + ".tmp";
+        fs.ensureDir(BACKUP_CONFIG_DIR, function (mkErr) {
+            if (mkErr) {
+                log.warn("Mirror skipped, ensureDir failed: " + mkErr.message);
+                return callback();
+            }
+            fs.writeFile(tmpPath, raw, function (wErr) {
+                if (wErr) {
+                    log.warn("Mirror write failed: " + wErr.message);
+                    return callback();
+                }
+                fs.rename(tmpPath, mirrorPath, function (rErr) {
+                    if (rErr) {
+                        log.warn("Mirror rename failed: " + rErr.message);
+                        fs.remove(tmpPath, function () {});
+                        return callback();
+                    }
+                    log.debug("Mirrored " + basename + " to " + mirrorPath);
+                    appendConfigHistory(basename, raw, callback);
+                });
+            });
+        });
+    });
+}
+
+function appendConfigHistory(basename, raw, callback) {
+    var name = basename.replace(/\.json$/i, "");
+    var dir = path.join(BACKUP_HISTORY_DIR, name);
+    fs.ensureDir(dir, function (mkErr) {
+        if (mkErr) {
+            log.warn("History skipped, ensureDir failed: " + mkErr.message);
+            return callback();
+        }
+        var stamp = new Date().toISOString().replace(/[:.]/g, "-");
+        var dest = path.join(dir, stamp + ".json");
+        var tmp = dest + ".tmp";
+        fs.writeFile(tmp, raw, function (wErr) {
+            if (wErr) {
+                log.warn("History write failed: " + wErr.message);
+                return callback();
+            }
+            fs.rename(tmp, dest, function (rErr) {
+                if (rErr) {
+                    log.warn("History rename failed: " + rErr.message);
+                    fs.remove(tmp, function () {});
+                    return callback();
+                }
+                pruneConfigHistory(dir, callback);
+            });
+        });
+    });
+}
+
+function pruneConfigHistory(dir, callback) {
+    fs.readdir(dir, function (err, files) {
+        if (err) {
+            return callback();
+        }
+        var entries = files.filter(function (f) {
+            return f.endsWith(".json");
+        });
+        if (entries.length <= HISTORY_KEEP) {
+            return callback();
+        }
+        entries.sort();
+        var excess = entries.slice(0, entries.length - HISTORY_KEEP);
+        async.each(
+            excess,
+            function (f, cb) {
+                fs.remove(path.join(dir, f), function () {
+                    cb();
+                });
+            },
+            function () {
+                callback();
+            }
+        );
+    });
+}
 
 // There are some redundancies here in how default and then specific machine files are loaded
 // ... as well as in the normal start-up sequence. Consider refactoring for efficiency.

--- a/config/profile_definition.js
+++ b/config/profile_definition.js
@@ -41,8 +41,12 @@ ProfileDefinition.prototype.read = function (force) {
         var data = fs.readFileSync(this.definition_file, "utf8");
         var definition = JSON.parse(data);
 
-        // Validate structure
-        if (!definition.auto_profile || !definition.auto_profile.profile_name) {
+        // Validate structure - require auto_profile with at least one
+        // recovery target (profile_name or snapshot_name).
+        if (
+            !definition.auto_profile ||
+            (!definition.auto_profile.profile_name && !definition.auto_profile.snapshot_name)
+        ) {
             log.warn("Invalid profile definition structure");
             this._cache = null;
             this._cacheTime = now;
@@ -222,6 +226,88 @@ ProfileDefinition.prototype.hasAutoProfileDefinition = function () {
     } catch (err) {
         return false;
     }
+};
+
+// Atomically write the fabmo-def.json file. Preserves any keys outside
+// auto_profile and lets callers patch a subset of auto_profile fields.
+// Writes are best-effort - if /fabmo-def is not writable, the error is
+// surfaced via callback but does not throw.
+ProfileDefinition.prototype._writePatch = function (patch, callback) {
+    var self = this;
+    var existing = {};
+    try {
+        if (this.exists()) {
+            existing = JSON.parse(fs.readFileSync(this.definition_file, "utf8"));
+        }
+    } catch (err) {
+        log.warn(
+            "Existing fabmo-def.json is unreadable; rewriting from scratch: " + err.message
+        );
+        existing = {};
+    }
+    var nextAutoProfile = Object.assign(
+        {},
+        existing.auto_profile || {},
+        patch.auto_profile || {}
+    );
+    // If a key in the patch is explicitly null, remove it.
+    Object.keys(patch.auto_profile || {}).forEach(function (k) {
+        if (patch.auto_profile[k] === null) {
+            delete nextAutoProfile[k];
+        }
+    });
+    // Default auto_profile fields if creating from scratch.
+    if (!("enabled" in nextAutoProfile)) {
+        nextAutoProfile.enabled = true;
+    }
+    if (!("force_reapply" in nextAutoProfile)) {
+        nextAutoProfile.force_reapply = false;
+    }
+    var next = Object.assign({}, existing, { auto_profile: nextAutoProfile });
+    var dir = path.dirname(this.definition_file);
+    var tmp = this.definition_file + ".tmp";
+    try {
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+    } catch (mkErr) {
+        log.warn("Could not ensure /fabmo-def directory: " + mkErr.message);
+        return callback && callback(mkErr);
+    }
+    fs.writeFile(tmp, JSON.stringify(next, null, 2), function (wErr) {
+        if (wErr) {
+            log.warn("Could not write fabmo-def.json tmp: " + wErr.message);
+            return callback && callback(wErr);
+        }
+        fs.rename(tmp, self.definition_file, function (rErr) {
+            if (rErr) {
+                log.warn("Could not rename fabmo-def.json: " + rErr.message);
+                try { fs.unlinkSync(tmp); } catch (e) { /* ignore */ }
+                return callback && callback(rErr);
+            }
+            self._cache = null;
+            self._cacheTime = 0;
+            log.info("fabmo-def.json updated");
+            callback && callback(null);
+        });
+    });
+};
+
+// Set the vanilla-profile fallback in fabmo-def.json.
+ProfileDefinition.prototype.setProfileName = function (profileName, callback) {
+    this._writePatch({ auto_profile: { profile_name: profileName } }, callback);
+};
+
+// Set the snapshot fallback in fabmo-def.json. Caller is responsible for
+// mirroring the snapshot's contents to /fabmo-def/snapshots/<name>/.
+ProfileDefinition.prototype.setSnapshotName = function (snapshotName, callback) {
+    this._writePatch({ auto_profile: { snapshot_name: snapshotName } }, callback);
+};
+
+// Clear the snapshot fallback. The vanilla profile_name (if any) remains
+// as the deeper fallback.
+ProfileDefinition.prototype.clearSnapshotName = function (callback) {
+    this._writePatch({ auto_profile: { snapshot_name: null } }, callback);
 };
 
 module.exports = new ProfileDefinition();

--- a/config/recovery_log.js
+++ b/config/recovery_log.js
@@ -1,0 +1,193 @@
+/*
+ * recovery_log.js
+ *
+ * Tracks config-corruption recovery events. When Config.prototype.load() falls
+ * back through its tier chain (backup -> working profile -> original profile),
+ * it records *which* tier won, the original parse error, and saves a copy of
+ * the corrupt source file for post-mortem analysis. Events are persisted as
+ * JSON-lines in /opt/fabmo_backup/recovery.log so they survive restarts and
+ * can be reviewed long after the fact.
+ *
+ * All write errors are logged and swallowed - failures here must never
+ * affect the primary config load path.
+ */
+
+var fs = require("fs-extra");
+var path = require("path");
+var log = require("../log").logger("recovery");
+
+var LOG_FILE = "/opt/fabmo_backup/recovery.log";
+var CORRUPT_DIR = "/opt/fabmo_backup/corrupt";
+var MAX_IN_MEMORY = 50;
+
+var events = [];
+var nextId = 1;
+var loaded = false;
+
+function loadFromDisk() {
+    if (loaded) {
+        return;
+    }
+    loaded = true;
+    try {
+        if (!fs.existsSync(LOG_FILE)) {
+            return;
+        }
+        var raw = fs.readFileSync(LOG_FILE, "utf8");
+        var lines = raw.split(/\n+/);
+        for (var i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (!line) {
+                continue;
+            }
+            try {
+                var ev = JSON.parse(line);
+                if (typeof ev.id === "number" && ev.id >= nextId) {
+                    nextId = ev.id + 1;
+                }
+                events.push(ev);
+            } catch (e) {
+                // ignore malformed lines
+            }
+        }
+        if (events.length > MAX_IN_MEMORY) {
+            events = events.slice(-MAX_IN_MEMORY);
+        }
+    } catch (e) {
+        log.warn("recovery_log: could not read " + LOG_FILE + ": " + e.message);
+    }
+}
+
+function rewriteLogFile() {
+    try {
+        fs.ensureDirSync(path.dirname(LOG_FILE));
+        var body =
+            events
+                .map(function (e) {
+                    return JSON.stringify(e);
+                })
+                .join("\n") + (events.length ? "\n" : "");
+        fs.writeFileSync(LOG_FILE, body);
+    } catch (e) {
+        log.warn("recovery_log: rewrite failed: " + e.message);
+    }
+}
+
+function record(event) {
+    loadFromDisk();
+    var ev = Object.assign(
+        {
+            id: nextId++,
+            timestamp: new Date().toISOString(),
+            acknowledged: false,
+        },
+        event
+    );
+    events.push(ev);
+    if (events.length > MAX_IN_MEMORY) {
+        events.shift();
+    }
+    try {
+        fs.ensureDirSync(path.dirname(LOG_FILE));
+        fs.appendFileSync(LOG_FILE, JSON.stringify(ev) + "\n");
+    } catch (e) {
+        log.warn("recovery_log: append failed: " + e.message);
+    }
+    log.info(
+        "recovery event recorded: " +
+            ev.config +
+            " recovered_from=" +
+            ev.recovered_from
+    );
+    return ev;
+}
+
+function getEvents(opts) {
+    loadFromDisk();
+    opts = opts || {};
+    if (opts.unacknowledgedOnly) {
+        return events.filter(function (e) {
+            return !e.acknowledged;
+        });
+    }
+    return events.slice();
+}
+
+function acknowledge(id) {
+    loadFromDisk();
+    var found = false;
+    for (var i = 0; i < events.length; i++) {
+        if (events[i].id === id && !events[i].acknowledged) {
+            events[i].acknowledged = true;
+            found = true;
+            break;
+        }
+    }
+    if (found) {
+        rewriteLogFile();
+    }
+    return found;
+}
+
+function acknowledgeAll() {
+    loadFromDisk();
+    var changed = false;
+    for (var i = 0; i < events.length; i++) {
+        if (!events[i].acknowledged) {
+            events[i].acknowledged = true;
+            changed = true;
+        }
+    }
+    if (changed) {
+        rewriteLogFile();
+    }
+    return changed;
+}
+
+// Save a copy of the (presumably corrupt) source file so it can be inspected
+// later. Returns the saved path via callback, or null on failure.
+function saveCorruptCopy(originalPath, callback) {
+    var done = function (result) {
+        if (typeof callback === "function") {
+            callback(result);
+        }
+    };
+    fs.ensureDir(CORRUPT_DIR, function (mkErr) {
+        if (mkErr) {
+            log.warn("recovery_log: could not ensure corrupt dir: " + mkErr.message);
+            return done(null);
+        }
+        fs.readFile(originalPath, function (rErr, data) {
+            if (rErr) {
+                // The file might not even be readable - log size 0 marker.
+                log.warn(
+                    "recovery_log: could not read corrupt source " +
+                        originalPath +
+                        ": " +
+                        rErr.message
+                );
+                return done(null);
+            }
+            var stamp = new Date().toISOString().replace(/[:.]/g, "-");
+            var dest = path.join(
+                CORRUPT_DIR,
+                stamp + "-" + path.basename(originalPath)
+            );
+            fs.writeFile(dest, data, function (wErr) {
+                if (wErr) {
+                    log.warn("recovery_log: could not write corrupt copy: " + wErr.message);
+                    return done(null);
+                }
+                done(dest);
+            });
+        });
+    });
+}
+
+module.exports = {
+    record: record,
+    getEvents: getEvents,
+    acknowledge: acknowledge,
+    acknowledgeAll: acknowledgeAll,
+    saveCorruptCopy: saveCorruptCopy,
+};

--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -2063,11 +2063,58 @@
                   <a id="btn-macros-restore"  class="button radius small" style="background-color:rgb(41, 175, 41)">Restore saved Macros</a>
               </div>
             </div>
-          
+
           </fieldset>
         </div>
-            
+
       </section>
+
+<!-- MY DEFAULT SETTINGS SECTION -->
+      <section>
+        <div class="row">
+          <fieldset>
+            <legend>My Default Settings</legend>
+            <div class="large-12 columns">
+              <p style="margin-bottom: 10px;">
+                Save the current configuration as your personal default. If a settings file is ever damaged
+                and the most recent backup can't be used, the machine will fall back to your saved default
+                instead of the factory profile.
+              </p>
+            </div>
+            <div class="large-8 columns">
+              <div class="row collapse">
+                <a id="btn-save-default" class="button radius small" style="background-color:rgb(83, 133, 224)">Save current settings as my default</a>
+                <a id="btn-reset-default" class="button radius small" style="background-color:rgb(41, 175, 41); margin-left:8px;">Reset to my default settings</a>
+              </div>
+            </div>
+            <div class="large-4 columns">
+              <div class="row collapse" style="line-height: 32px;">
+                <span>Current default: </span><span id="current-default-name" style="font-weight: bold;">none</span>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </section>
+
+<!-- Save-as-default dialog. Inline modal because the app runs in a
+     sandboxed iframe that blocks window.prompt(). -->
+      <div id="save-default-dialog" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); z-index:9999;">
+        <div style="background:white; max-width:420px; margin:80px auto; padding:20px; border-radius:6px;">
+          <h4 style="margin-top:0;">Save current settings as my default</h4>
+          <div style="margin-bottom:10px;">
+            <label>Name <span style="color:#999;font-weight:normal;">(1-25 chars: letters, digits, _ or -)</span></label>
+            <input type="text" id="save-default-name" maxlength="25" autocomplete="off">
+          </div>
+          <div style="margin-bottom:14px;">
+            <label>Description <span style="color:#999;font-weight:normal;">(optional)</span></label>
+            <input type="text" id="save-default-description" autocomplete="off">
+          </div>
+          <div style="text-align:right;">
+            <a id="save-default-cancel" class="button radius small secondary" style="margin-right:8px;">Cancel</a>
+            <a id="save-default-confirm" class="button radius small" style="background-color:rgb(83, 133, 224); color:#fff;">Save</a>
+          </div>
+        </div>
+      </div>
 
     </div>
 

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -824,3 +824,135 @@ function ensureProfileDisplayCorrect() {
         }
     });
 }
+
+// "Save current settings as my default": create a snapshot from the
+// current /opt/fabmo/config + macros, then mark it as the user-default
+// fallback. This is the user-friendly entry into the snapshot system -
+// it does not modify any shipped profiles.
+function refreshDefaultSnapshotName() {
+    fetch('/snapshots')
+        .then(function (r) { return r.json(); })
+        .then(function (resp) {
+            if (resp && resp.status === 'success' && resp.data && resp.data.snapshots) {
+                var def = null;
+                for (var i = 0; i < resp.data.snapshots.length; i++) {
+                    if (resp.data.snapshots[i].is_user_default) {
+                        def = resp.data.snapshots[i];
+                        break;
+                    }
+                }
+                $('#current-default-name').text(def ? def.name : 'none');
+            }
+        })
+        .catch(function () { /* leave display alone on transient errors */ });
+}
+
+// The app is sandboxed and cannot use window.prompt(), so we drive an
+// inline modal in index.html (#save-default-dialog).
+$('#btn-save-default').click(function () {
+    $('#save-default-name').val('');
+    $('#save-default-description').val('');
+    $('#save-default-dialog').show();
+    setTimeout(function () { $('#save-default-name').focus(); }, 0);
+});
+
+$('#save-default-cancel').click(function () {
+    $('#save-default-dialog').hide();
+});
+
+$('#save-default-confirm').click(function () {
+    // Spaces are a common natural input; auto-convert to underscores
+    // rather than rejecting. Collapse runs of whitespace to a single _.
+    var name = ($('#save-default-name').val() || '').trim().replace(/\s+/g, '_');
+    var description = $('#save-default-description').val() || '';
+    if (!name) {
+        fabmo.notify('error', 'A name is required.');
+        return;
+    }
+    if (!/^[a-zA-Z0-9_-]{1,25}$/.test(name)) {
+        fabmo.notify('error', 'Name must be 1-25 characters: letters, digits, _ or -.');
+        return;
+    }
+    $('#save-default-dialog').hide();
+
+    fetch('/snapshots', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name, description: description })
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (resp) {
+        if (!resp || resp.status !== 'success') {
+            var msg = resp && resp.message ? resp.message : 'unknown error';
+            throw new Error(msg);
+        }
+        return fetch('/snapshots/' + encodeURIComponent(name) + '/set-default', {
+            method: 'POST'
+        }).then(function (r) { return r.json(); });
+    })
+    .then(function (resp) {
+        if (!resp || resp.status !== 'success') {
+            var msg = resp && resp.message ? resp.message : 'could not mark as default';
+            throw new Error('Snapshot saved but not marked as default: ' + msg);
+        }
+        fabmo.notify('success', 'Saved current settings as your default: ' + name);
+        refreshDefaultSnapshotName();
+    })
+    .catch(function (err) {
+        fabmo.notify('error', err.message || 'Failed to save default.');
+    });
+});
+
+// Reset to whatever snapshot is currently marked as the user-default.
+// Uses fabmo.showModal (no input fields needed) since the sandbox blocks
+// window.confirm() the same way it blocks prompt().
+$('#btn-reset-default').click(function () {
+    fetch('/snapshots')
+        .then(function (r) { return r.json(); })
+        .then(function (resp) {
+            var def = null;
+            if (resp && resp.status === 'success' && resp.data && resp.data.snapshots) {
+                for (var i = 0; i < resp.data.snapshots.length; i++) {
+                    if (resp.data.snapshots[i].is_user_default) {
+                        def = resp.data.snapshots[i];
+                        break;
+                    }
+                }
+            }
+            if (!def) {
+                fabmo.notify('warning', 'No default is set yet. Use "Save current settings as my default" first.');
+                return;
+            }
+            fabmo.showModal({
+                title: 'Reset to my default settings?',
+                message: 'This will replace your current configuration and macros with your saved default "' + def.name + '". The tool will restart. A snapshot of your current settings is saved automatically first, so you can recover if needed.',
+                okText: 'Reset',
+                cancelText: 'Cancel',
+                ok: function () {
+                    fabmo.notify('info', 'Restoring "' + def.name + '"...');
+                    fetch('/snapshots/' + encodeURIComponent(def.name) + '/restore', {
+                        method: 'POST'
+                    })
+                        .then(function (r) { return r.json(); })
+                        .then(function (resp2) {
+                            if (!resp2 || resp2.status !== 'success') {
+                                var msg = resp2 && resp2.message ? resp2.message : 'unknown error';
+                                fabmo.notify('error', 'Reset failed: ' + msg);
+                            }
+                            // On success the engine restarts; the page will
+                            // reload on its own once it comes back up.
+                        })
+                        .catch(function (err) {
+                            fabmo.notify('error', 'Reset failed: ' + err.message);
+                        });
+                },
+                cancel: function () {}
+            });
+        })
+        .catch(function (err) {
+            fabmo.notify('error', 'Could not check for default: ' + err.message);
+        });
+});
+
+// Show current default on load.
+refreshDefaultSnapshotName();

--- a/engine.js
+++ b/engine.js
@@ -896,9 +896,75 @@ Engine.prototype.start = function (callback) {
                                     log.warn("Could not mark profile as applied: " + markErr.message);
                                 }
 
+                                // /opt-loss recovery: if fabmo-def names a
+                                // user-default snapshot AND its mirror at
+                                // /fabmo-def/snapshots/<name>/ exists AND
+                                // the in-/opt .default pointer is absent
+                                // (i.e. there's no operational default in
+                                // /opt right now), restore the snapshot
+                                // from the mirror over the just-applied
+                                // profile defaults. We force a restart
+                                // instead of using the in-process reload
+                                // so the engine reads the restored files
+                                // cleanly.
+                                var definition = this.pending_profile_change &&
+                                                 this.pending_profile_change.definition;
+                                var snapshotName = definition &&
+                                                   definition.auto_profile &&
+                                                   definition.auto_profile.snapshot_name;
+                                var defaultPointer = "/opt/fabmo_snapshots/.default";
+                                var mirrorDir = snapshotName
+                                    ? "/fabmo-def/snapshots/" + snapshotName
+                                    : null;
+                                var shouldRecover = !!(
+                                    snapshotName &&
+                                    mirrorDir &&
+                                    fs.existsSync(mirrorDir) &&
+                                    !fs.existsSync(defaultPointer)
+                                );
+
+                                if (shouldRecover) {
+                                    log.info(
+                                        "Mirror snapshot present and no operational default in /opt; recovering '" +
+                                            snapshotName +
+                                            "' from " +
+                                            mirrorDir
+                                    );
+                                    var snapshotsModule = require("./snapshots");
+                                    snapshotsModule.recoverFromMirror(snapshotName, function (recErr) {
+                                        if (recErr) {
+                                            log.warn(
+                                                "Mirror recovery failed (continuing with profile-only state): " +
+                                                    recErr.message
+                                            );
+                                        }
+                                        // Our snapshot recovery is the canonical restore for this
+                                        // boot. Remove any pre-auto-profile-backup that the
+                                        // auto-profile flow may have just created (e.g. from stale
+                                        // /opt/fabmo_backup left over after a partial /opt wipe).
+                                        // Without this, the dashboard's backup-restore modal would
+                                        // fire on the next page load and offer to re-restore that
+                                        // older state, racing with the snapshot we just put down.
+                                        var configWatcher = require("./config_watcher");
+                                        configWatcher.cleanupPreAutoProfileBackup(function (cuErr) {
+                                            if (cuErr) {
+                                                log.warn(
+                                                    "Could not clean up pre-auto-profile backup after recovery: " +
+                                                        cuErr.message
+                                                );
+                                            }
+                                            log.info("Restarting after /opt-loss recovery...");
+                                            setTimeout(function () {
+                                                process.exit(0);
+                                            }, 2000);
+                                        });
+                                    });
+                                    return;
+                                }
+
                                 // Skip restart if flagged - config was already loaded correctly
                                 // OR this is a first run where next startup will load profile fresh
-                                var skipRestart = this.pending_profile_change && 
+                                var skipRestart = this.pending_profile_change &&
                                                   this.pending_profile_change.skipRestart;
 
                                 if (skipRestart) {

--- a/files/fabmo.service
+++ b/files/fabmo.service
@@ -7,8 +7,10 @@ Wants=network-online.target
 ExecStart=/usr/bin/node /fabmo/server.js
 Type=simple
 User=root
-Restart=on-failure
+Restart=always
 RestartSec=3
+StartLimitBurst=5
+StartLimitIntervalSec=60
 SyslogIdentifier=FBMO
 WorkingDirectory = /fabmo/
 

--- a/profiles.js
+++ b/profiles.js
@@ -31,6 +31,7 @@ var log = require("./log").logger("profiles");
 var ncp = require("ncp").ncp;
 var path = require("path");
 var util = require("./util");
+var snapshots = require("./snapshots");
 
 // Directories affected by profiles
 var PROFILE_DIRS = ["config", "macros", "apps"];
@@ -152,6 +153,18 @@ var apply = function (profileName, callback) {
             log.info("Auto-profile application - skipping config directory (already complete)");
         }
 
+        // Snapshot the current state before the destructive copy. If the
+        // user (or we) made a mistake choosing the profile, restoring from
+        // the auto-snapshot rolls back the change. Best-effort: failures
+        // are logged and do not block the profile change itself.
+        snapshots.createAuto("auto_pre_profile", function (snapErr) {
+            if (snapErr) {
+                log.warn("auto_pre_profile snapshot failed (continuing): " + snapErr.message);
+            }
+            doApply();
+        });
+
+        function doApply() {
         // For every directory affected by profiles...
         // Use eachSeries to copy directories sequentially (avoids I/O race conditions)
         async.eachSeries(
@@ -237,6 +250,7 @@ var apply = function (profileName, callback) {
                 });
             }
         );
+        }
     } else {
         log.warn(profileName + ", user selected profile.");
         callback(null, "not default profile"); // Continue without error

--- a/routes/config.js
+++ b/routes/config.js
@@ -4,6 +4,8 @@ var config = require("../config");
 var log = require("../log").logger("config-routes");
 var engine = require("../engine");
 var profiles = require("../profiles");
+var recoveryLog = require("../config/recovery_log");
+var snapshots = require("../snapshots");
 
 const fs = require("fs");
 const path = require("path");
@@ -503,33 +505,73 @@ var post_manual_profile_change = function (req, res, next) {
 };
 
 // Helper function for manual profile changes
+//
+// IMPORTANT FLOW NOTE: config.engine.set("profile", ...) routes through
+// EngineConfig.update which detects a profile change, calls
+// profiles.apply(), and then synchronously calls process.exit(1) (see
+// config/engine_config.js). Control never returns to its callback. Any
+// bookkeeping we want to do for this manual change therefore has to
+// happen BEFORE we call config.engine.set - including updating
+// fabmo-def.json so /opt-loss recovery picks up the new profile.
 function applyManualProfileChange(profileName, res, next) {
-    // Set the engine config to the user's choice
-    config.engine.set("profile", profileName, function (err) {
-        if (err) {
-            log.error("Failed to set manual profile: " + err.message);
-            return res.json({
-                status: "error",
-                message: "Failed to set profile: " + err.message,
-            });
+    var profileDef = require("../config/profile_definition");
+    var ConfigClass = require("../config/config").Config;
+    var snapshots = require("../snapshots");
+    var profileDirName = ConfigClass.resolveProfileDirectory(profileName);
+
+    log.info(
+        "Updating fabmo-def.profile_name: '" + profileName + "' -> '" + profileDirName + "'"
+    );
+
+    // Step 1: update fabmo-def.profile_name (the vanilla fallback).
+    profileDef.setProfileName(profileDirName, function (pdErr) {
+        if (pdErr) {
+            log.warn("Could not update fabmo-def.json profile_name: " + pdErr.message);
         }
 
-        log.info("Manual profile change completed: " + profileName);
+        // Step 2: clear any previously-blessed user-default snapshot.
+        // The user has explicitly picked a new baseline, so the old
+        // snapshot is no longer the right fallback. clearDefault
+        // removes snapshot_name from fabmo-def, deletes the
+        // /fabmo-def/snapshots/<name>/ mirror, and clears the in-/opt
+        // .default pointer. The operational snapshot at
+        // /opt/fabmo_snapshots/<name>/ stays so the user can re-bless
+        // it later if they want.
+        snapshots.clearDefault(function (cdErr) {
+            if (cdErr) {
+                log.warn("Could not clear user-default snapshot after profile change: " + cdErr.message);
+            } else {
+                log.info("Profile change superseded any previously-blessed user-default snapshot");
+            }
 
-        res.json({
-            status: "success",
-            message: "Profile change initiated",
+            // Send the response before triggering the engine-exiting
+            // call. The dashboard treats the subsequent connection
+            // loss as the "engine restarting" signal.
+            res.json({
+                status: "success",
+                message: "Profile change initiated",
+            });
+            log.info("fabmo-def updated; handing off to engine profile-change pipeline");
+            res.end();
+
+            // Step 3: actually trigger the profile change. engine_config
+            // will call profiles.apply and then process.exit(1) - we
+            // don't expect this callback to fire on the happy path.
+            config.engine.set("profile", profileName, function (err) {
+                if (err) {
+                    log.error("Failed to set manual profile: " + err.message);
+                    return;
+                }
+                log.info("Manual profile change completed: " + profileName);
+                // Fallback restart in case engine_config didn't exit
+                // (e.g. "not default profile" branch). Restart=always
+                // in systemd handles bringing us back.
+                setTimeout(function () {
+                    log.info("Restarting for manual profile change...");
+                    process.exit(0);
+                }, 2000);
+            });
         });
-        
-        log.info("Response sent, waiting before restart...");
-        res.end();
-        next();
-
-        // Restart after a short delay
-        setTimeout(function () {
-            log.info("Restarting for manual profile change...");
-            process.exit(0);
-        }, 2000);
     });
 
     next();
@@ -737,6 +779,107 @@ var post_restore_backup = function (req, res, next) {
     }
 };
 
+// Return recovery events recorded when Config.load() fell back through
+// its backup -> profile -> shipped-profile chain. The optional query
+// parameter ?unacknowledged=1 filters to events the user hasn't dismissed.
+var get_recovery_events = function (req, res, next) {
+    var unackOnly = req.query && (req.query.unacknowledged === "1" || req.query.unacknowledged === "true");
+    var events = recoveryLog.getEvents({ unacknowledgedOnly: !!unackOnly });
+    res.json({ status: "success", data: { events: events } });
+};
+
+// Acknowledge a single event by id (POST body { id }) or all events if no id.
+var post_acknowledge_recovery = function (req, res, next) {
+    var id = req.body && req.body.id;
+    var changed;
+    if (id === undefined || id === null) {
+        changed = recoveryLog.acknowledgeAll();
+    } else {
+        var nId = parseInt(id, 10);
+        if (isNaN(nId)) {
+            return res.json({ status: "error", message: "id must be a number" });
+        }
+        changed = recoveryLog.acknowledge(nId);
+    }
+    res.json({ status: "success", data: { changed: !!changed } });
+};
+
+// List all snapshots (user-created and auto), newest first.
+var get_snapshots = function (req, res, next) {
+    snapshots.list(function (err, list) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({ status: "success", data: { snapshots: list } });
+    });
+};
+
+// Create a user snapshot. Body: { name, description? }.
+var post_snapshot = function (req, res, next) {
+    var name = req.body && req.body.name;
+    var description = req.body && req.body.description;
+    snapshots.create(name, description, function (err) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({ status: "success", data: { name: name } });
+    });
+};
+
+// Restore a snapshot by name. Engine restarts shortly after.
+var post_snapshot_restore = function (req, res, next) {
+    var name = req.params && req.params.name;
+    snapshots.restore(name, function (err, result) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({
+            status: "success",
+            data: result,
+            message: "Snapshot restored - engine will restart",
+        });
+        setTimeout(function () {
+            log.info("Restarting engine after snapshot restore...");
+            process.exit(0);
+        }, 1000);
+    });
+};
+
+// Delete a user snapshot (auto-snapshots rotate themselves).
+var delete_snapshot = function (req, res, next) {
+    var name = req.params && req.params.name;
+    snapshots.remove(name, function (err) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({ status: "success" });
+    });
+};
+
+// Mark a snapshot as the user-default fallback. The recovery chain will
+// reach for it after the auto-backup mirror but before the generic
+// profile defaults.
+var post_set_default_snapshot = function (req, res, next) {
+    var name = req.params && req.params.name;
+    snapshots.setDefault(name, function (err) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({ status: "success", data: { name: name } });
+    });
+};
+
+// Clear the user-default fallback pointer (recovery falls back to
+// profiles as before).
+var post_clear_default_snapshot = function (req, res, next) {
+    snapshots.clearDefault(function (err) {
+        if (err) {
+            return res.json({ status: "error", message: err.message });
+        }
+        res.json({ status: "success" });
+    });
+};
+
 module.exports = function (server) {
     server.post("/macros/restore", handleMacrosRestore);
     server.get("/macros/backup", backup_macros);
@@ -755,4 +898,14 @@ module.exports = function (server) {
     server.post('/config/dismiss-backup-restore', dismiss_backup_restore);
     server.get("/config/backup-restore-status", get_backup_restore_status);
     server.post("/config/restore-backup", post_restore_backup);
+
+    server.get("/config/recovery-events", get_recovery_events);
+    server.post("/config/recovery-events/acknowledge", post_acknowledge_recovery);
+
+    server.get("/snapshots", get_snapshots);
+    server.post("/snapshots", post_snapshot);
+    server.post("/snapshots/clear-default", post_clear_default_snapshot);
+    server.post("/snapshots/:name/restore", post_snapshot_restore);
+    server.post("/snapshots/:name/set-default", post_set_default_snapshot);
+    server.del("/snapshots/:name", delete_snapshot);
 };

--- a/snapshots.js
+++ b/snapshots.js
@@ -1,0 +1,648 @@
+/*
+ * snapshots.js
+ *
+ * User-controlled named restore points for machine configuration. A snapshot
+ * captures /opt/fabmo/config/ (minus runtime state and secrets) and
+ * /opt/fabmo/macros/ as a frozen point-in-time copy. Snapshots are separate
+ * from the chokidar-driven backup system - backups handle "my live config
+ * just got corrupted, restore the most recent good copy"; snapshots handle
+ * "bring me back to a tuned baseline I explicitly trust."
+ *
+ * Auto-snapshots are created before potentially destructive transitions
+ * (profile change, snapshot restore). They use a reserved kind prefix and
+ * are rotated to keep disk usage bounded.
+ *
+ * Restore is additive (overwrites existing files but does not delete files
+ * absent from the snapshot). This protects forward-compatibility when newer
+ * fabmo versions introduce config files the snapshot predates.
+ */
+
+var fs = require("fs-extra");
+var path = require("path");
+var async = require("async");
+var log = require("./log").logger("snapshots");
+var machine = require("./machine");
+
+var SNAPSHOT_DIR = "/opt/fabmo_snapshots";
+var DEFAULT_POINTER = "/opt/fabmo_snapshots/.default";
+var LIVE_CONFIG_DIR = "/opt/fabmo/config";
+var LIVE_MACROS_DIR = "/opt/fabmo/macros";
+var MAX_AUTO_PER_KIND = 5;
+
+// Snapshots marked as the user-default are mirrored here so they survive
+// /opt being wiped (the whole reason /fabmo-def exists outside /opt).
+var FABMO_DEF_SNAPSHOTS_DIR = "/fabmo-def/snapshots";
+
+// Files in /opt/fabmo/config/ that should never be captured in a snapshot.
+// instance.json is runtime state (position/offsets) that belongs to the
+// current session. auth_secret is a security token - restoring it could
+// invalidate active sessions in surprising ways.
+var EXCLUDED_FILES = ["instance.json", "auth_secret"];
+
+// Name rules for user-created snapshots: alphanumeric plus _- only,
+// 1-25 chars. Reserved prefixes are owned by the auto-snapshot system.
+var USER_NAME_RE = /^[a-zA-Z0-9_-]{1,25}$/;
+var RESERVED_PREFIXES = ["auto_pre_restore", "auto_pre_profile"];
+
+function isReservedName(name) {
+    for (var i = 0; i < RESERVED_PREFIXES.length; i++) {
+        var p = RESERVED_PREFIXES[i];
+        if (name === p || name.indexOf(p + "_") === 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function isValidUserName(name) {
+    return typeof name === "string" && USER_NAME_RE.test(name) && !isReservedName(name);
+}
+
+function isIdle() {
+    try {
+        return machine && machine.machine && machine.machine.status && machine.machine.status.state === "idle";
+    } catch (e) {
+        return false;
+    }
+}
+
+function snapshotPath(name) {
+    return path.join(SNAPSHOT_DIR, name);
+}
+
+function shouldIncludeForSnapshot(srcPath) {
+    var base = path.basename(srcPath);
+    if (EXCLUDED_FILES.indexOf(base) !== -1) {
+        return false;
+    }
+    // Skip dotfiles like .auto_profile_applied - those are state markers.
+    if (base.charAt(0) === ".") {
+        return false;
+    }
+    return true;
+}
+
+// Internal create — used by both user-initiated and auto paths. Does not
+// enforce idle (callers decide). Writes config/, macros/, and snapshot_info.json.
+function _create(name, opts, callback) {
+    opts = opts || {};
+    var dest = snapshotPath(name);
+    var configDest = path.join(dest, "config");
+    var macrosDest = path.join(dest, "macros");
+
+    fs.ensureDir(dest, function (err) {
+        if (err) {
+            return callback(err);
+        }
+        async.series(
+            [
+                function (cb) {
+                    fs.ensureDir(configDest, cb);
+                },
+                function (cb) {
+                    if (!fs.existsSync(LIVE_CONFIG_DIR)) {
+                        return cb();
+                    }
+                    fs.copy(LIVE_CONFIG_DIR, configDest, { filter: shouldIncludeForSnapshot }, cb);
+                },
+                function (cb) {
+                    if (!fs.existsSync(LIVE_MACROS_DIR)) {
+                        return cb();
+                    }
+                    fs.ensureDir(macrosDest, function (eErr) {
+                        if (eErr) {
+                            return cb(eErr);
+                        }
+                        fs.copy(LIVE_MACROS_DIR, macrosDest, cb);
+                    });
+                },
+                function (cb) {
+                    var info = {
+                        name: name,
+                        kind: opts.kind || "user",
+                        description: opts.description || "",
+                        created_at: new Date().toISOString(),
+                    };
+                    fs.writeFile(path.join(dest, "snapshot_info.json"), JSON.stringify(info, null, 2), cb);
+                },
+            ],
+            function (err) {
+                if (err) {
+                    log.warn("snapshot create failed for " + name + ": " + err.message);
+                    fs.remove(dest, function () {});
+                    return callback(err);
+                }
+                log.info("snapshot created: " + name + " (" + (opts.kind || "user") + ")");
+                callback(null);
+            }
+        );
+    });
+}
+
+// Public: create a user-initiated snapshot. Enforces idle + name rules +
+// non-collision.
+function create(name, description, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (!isValidUserName(name)) {
+        return callback(new Error("Invalid snapshot name (1-25 chars, letters/digits/_-, no reserved prefix)"));
+    }
+    if (!isIdle()) {
+        return callback(new Error("Machine must be idle to create a snapshot"));
+    }
+    if (fs.existsSync(snapshotPath(name))) {
+        return callback(new Error("A snapshot named '" + name + "' already exists"));
+    }
+    _create(name, { kind: "user", description: description || "" }, callback);
+}
+
+// Public: create an automatic snapshot of the given kind, prune older ones
+// of the same kind. Bypasses idle and name-collision checks since callers
+// are the engine itself, not user actions.
+function createAuto(kind, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (RESERVED_PREFIXES.indexOf(kind) === -1) {
+        return callback(new Error("Unknown auto-snapshot kind: " + kind));
+    }
+    // Only create if there's something to capture - avoids empty snapshots
+    // during fresh installs.
+    if (!fs.existsSync(LIVE_CONFIG_DIR)) {
+        log.debug("auto-snapshot skipped: no live config dir yet (" + kind + ")");
+        return callback(null, null);
+    }
+    var stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    var name = kind + "_" + stamp;
+    _create(name, { kind: kind, description: "Automatic " + kind + " snapshot" }, function (err) {
+        if (err) {
+            return callback(err);
+        }
+        pruneAuto(kind, function () {
+            callback(null, name);
+        });
+    });
+}
+
+function pruneAuto(kind, callback) {
+    fs.readdir(SNAPSHOT_DIR, function (err, entries) {
+        if (err) {
+            return callback();
+        }
+        var prefix = kind + "_";
+        var matching = entries.filter(function (e) {
+            return e.indexOf(prefix) === 0;
+        });
+        if (matching.length <= MAX_AUTO_PER_KIND) {
+            return callback();
+        }
+        // Names contain ISO timestamps, so lexicographic sort = chronological.
+        matching.sort();
+        var excess = matching.slice(0, matching.length - MAX_AUTO_PER_KIND);
+        async.each(
+            excess,
+            function (name, cb) {
+                fs.remove(snapshotPath(name), function (rmErr) {
+                    if (rmErr) {
+                        log.warn("could not prune auto snapshot " + name + ": " + rmErr.message);
+                    }
+                    cb();
+                });
+            },
+            function () {
+                callback();
+            }
+        );
+    });
+}
+
+// List all snapshots (user and auto). Sorted newest-first by created_at.
+// Each snapshot's is_user_default is set if it currently holds the
+// "user default" title.
+function list(callback) {
+    fs.ensureDir(SNAPSHOT_DIR, function (err) {
+        if (err) {
+            return callback(err);
+        }
+        var defaultName = getDefault();
+        fs.readdir(SNAPSHOT_DIR, function (rErr, entries) {
+            if (rErr) {
+                return callback(rErr);
+            }
+            var snapshots = [];
+            async.each(
+                entries,
+                function (name, cb) {
+                    var infoFile = path.join(SNAPSHOT_DIR, name, "snapshot_info.json");
+                    fs.readFile(infoFile, "utf8", function (readErr, data) {
+                        if (readErr) {
+                            return cb();
+                        }
+                        try {
+                            var info = JSON.parse(data);
+                            info.name = name;
+                            info.is_user_default = name === defaultName;
+                            snapshots.push(info);
+                        } catch (e) {
+                            log.warn("snapshot " + name + " has invalid info: " + e.message);
+                        }
+                        cb();
+                    });
+                },
+                function () {
+                    snapshots.sort(function (a, b) {
+                        return (b.created_at || "").localeCompare(a.created_at || "");
+                    });
+                    callback(null, snapshots);
+                }
+            );
+        });
+    });
+}
+
+// Read the name of the user-default snapshot, or null if none is set.
+// Sync because it's called from the config-load fallback path during
+// engine boot, where async would complicate the chain.
+function getDefault() {
+    try {
+        if (!fs.existsSync(DEFAULT_POINTER)) {
+            return null;
+        }
+        var name = fs.readFileSync(DEFAULT_POINTER, "utf8").trim();
+        if (!name) {
+            return null;
+        }
+        // Verify the pointed-at snapshot still exists. A stale pointer
+        // (snapshot was deleted out from under us) should behave the
+        // same as no default at all.
+        if (!fs.existsSync(snapshotPath(name))) {
+            log.warn("user-default snapshot pointer is stale: " + name);
+            return null;
+        }
+        return name;
+    } catch (e) {
+        log.warn("could not read default snapshot pointer: " + e.message);
+        return null;
+    }
+}
+
+// Mark a snapshot as the user-default fallback. Mirrors the snapshot to
+// /fabmo-def/snapshots/<name>/ and records the name in fabmo-def.json so
+// the choice survives /opt being wiped. Lazy-requires profile_definition
+// to avoid a circular dep.
+//
+// Only user-named snapshots are eligible: auto-rotated snapshots
+// disappear under their rotation policy, which would silently break the
+// fallback link.
+function setDefault(name, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (!isValidUserName(name)) {
+        return callback(new Error("Only user-named snapshots can be set as default"));
+    }
+    var src = snapshotPath(name);
+    if (!fs.existsSync(src)) {
+        return callback(new Error("Snapshot not found: " + name));
+    }
+    var profileDef;
+    try {
+        profileDef = require("./config/profile_definition");
+    } catch (e) {
+        return callback(new Error("profile_definition unavailable: " + e.message));
+    }
+
+    var previousDefault = getDefault();
+    var newMirror = path.join(FABMO_DEF_SNAPSHOTS_DIR, name);
+
+    async.series(
+        [
+            // Ensure the cross-/opt mirror directory exists.
+            function (cb) {
+                fs.ensureDir(FABMO_DEF_SNAPSHOTS_DIR, cb);
+            },
+            // If a different snapshot was previously the default, clear
+            // its mirror so /fabmo-def only ever holds the active one.
+            function (cb) {
+                if (!previousDefault || previousDefault === name) {
+                    return cb();
+                }
+                var oldMirror = path.join(FABMO_DEF_SNAPSHOTS_DIR, previousDefault);
+                fs.remove(oldMirror, function () { cb(); });
+            },
+            // Mirror the snapshot to /fabmo-def. This is the
+            // protection-against-/opt-loss step; if it fails, the whole
+            // setDefault fails so the user knows their fallback isn't
+            // protected.
+            function (cb) {
+                fs.copy(src, newMirror, { overwrite: true }, function (err) {
+                    if (err) {
+                        return cb(new Error("Could not mirror snapshot to /fabmo-def: " + err.message));
+                    }
+                    cb();
+                });
+            },
+            // Record the snapshot name in fabmo-def.json.
+            function (cb) {
+                profileDef.setSnapshotName(name, function (err) {
+                    if (err) {
+                        log.warn("Snapshot mirrored but fabmo-def.json update failed: " + err.message);
+                    }
+                    cb();
+                });
+            },
+            // Ensure fabmo-def.json also has profile_name set, so the
+            // /opt-loss recovery flow (which runs through the auto-profile
+            // pipeline) can resolve a target profile. If profile_name was
+            // never set (user blessed a snapshot without ever changing
+            // profile), populate it from the current engine config. This
+            // converts to the directory name form since check_auto_profile
+            // resolves targets that way.
+            function (cb) {
+                try {
+                    var existing = profileDef.read(true);
+                    var hasProfileName = !!(
+                        existing &&
+                        existing.auto_profile &&
+                        existing.auto_profile.profile_name
+                    );
+                    if (hasProfileName) {
+                        return cb();
+                    }
+                    var configModule = require("./config");
+                    var currentProfile =
+                        configModule &&
+                        configModule.engine &&
+                        configModule.engine.get &&
+                        configModule.engine.get("profile");
+                    if (!currentProfile) {
+                        return cb();
+                    }
+                    var ConfigClass = require("./config/config").Config;
+                    var dirName = ConfigClass.resolveProfileDirectory(currentProfile);
+                    profileDef.setProfileName(dirName, function (e) {
+                        if (e) {
+                            log.warn("Auto-populate of profile_name failed: " + e.message);
+                        }
+                        cb();
+                    });
+                } catch (e) {
+                    log.warn("Could not auto-populate profile_name: " + e.message);
+                    cb();
+                }
+            },
+            // Write the in-/opt pointer used by the recovery chain.
+            function (cb) {
+                fs.ensureDir(SNAPSHOT_DIR, function (e) {
+                    if (e) {
+                        return cb(e);
+                    }
+                    fs.writeFile(DEFAULT_POINTER, name, cb);
+                });
+            },
+        ],
+        function (err) {
+            if (err) {
+                log.warn("setDefault failed for " + name + ": " + err.message);
+                return callback(err);
+            }
+            log.info("user-default snapshot set to: " + name);
+            callback(null);
+        }
+    );
+}
+
+function clearDefault(callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    var currentName = getDefault();
+    var profileDef;
+    try {
+        profileDef = require("./config/profile_definition");
+    } catch (e) {
+        profileDef = null;
+    }
+
+    async.series(
+        [
+            // Remove the /fabmo-def mirror for the previously-blessed
+            // snapshot, if any.
+            function (cb) {
+                if (!currentName) {
+                    return cb();
+                }
+                var mirror = path.join(FABMO_DEF_SNAPSHOTS_DIR, currentName);
+                fs.remove(mirror, function () { cb(); });
+            },
+            // Clear the snapshot field in fabmo-def.json (profile_name
+            // remains as the deeper fallback).
+            function (cb) {
+                if (!profileDef) {
+                    return cb();
+                }
+                profileDef.clearSnapshotName(function () { cb(); });
+            },
+            // Remove the in-/opt pointer.
+            function (cb) {
+                if (!fs.existsSync(DEFAULT_POINTER)) {
+                    return cb();
+                }
+                fs.remove(DEFAULT_POINTER, function () { cb(); });
+            },
+        ],
+        function (err) {
+            if (!err) {
+                log.info("user-default snapshot cleared");
+            }
+            callback(err);
+        }
+    );
+}
+
+// Restore a snapshot over the live config + macros. Auto-snapshots the
+// current state first so an accidental restore is itself reversible.
+// Caller is responsible for triggering an engine restart after the callback.
+function restore(name, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (typeof name !== "string" || name.length === 0) {
+        return callback(new Error("Snapshot name required"));
+    }
+    var dest = snapshotPath(name);
+    if (!fs.existsSync(dest)) {
+        return callback(new Error("Snapshot not found: " + name));
+    }
+    if (!isIdle()) {
+        return callback(new Error("Machine must be idle to restore a snapshot"));
+    }
+    createAuto("auto_pre_restore", function (autoErr, autoName) {
+        if (autoErr) {
+            log.warn("pre-restore snapshot failed (continuing): " + autoErr.message);
+        }
+        var snapConfigDir = path.join(dest, "config");
+        var snapMacrosDir = path.join(dest, "macros");
+        async.series(
+            [
+                function (cb) {
+                    if (!fs.existsSync(snapConfigDir)) {
+                        return cb();
+                    }
+                    fs.copy(snapConfigDir, LIVE_CONFIG_DIR, { overwrite: true }, cb);
+                },
+                function (cb) {
+                    if (!fs.existsSync(snapMacrosDir)) {
+                        return cb();
+                    }
+                    fs.copy(snapMacrosDir, LIVE_MACROS_DIR, { overwrite: true }, cb);
+                },
+            ],
+            function (err) {
+                if (err) {
+                    log.error("snapshot restore failed for " + name + ": " + err.message);
+                    return callback(err);
+                }
+                log.info("snapshot restored: " + name);
+                callback(null, { pre_restore_snapshot: autoName });
+            }
+        );
+    });
+}
+
+// Delete a user snapshot. Auto-snapshots are managed by their own pruning;
+// this endpoint refuses to delete them so we never accidentally throw away
+// safety nets.
+function remove(name, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (!isValidUserName(name)) {
+        return callback(new Error("Only user snapshots can be deleted (auto snapshots rotate themselves)"));
+    }
+    var dest = snapshotPath(name);
+    if (!fs.existsSync(dest)) {
+        return callback(new Error("Snapshot not found: " + name));
+    }
+    var wasDefault = getDefault() === name;
+    fs.remove(dest, function (err) {
+        if (err) {
+            return callback(err);
+        }
+        log.info("snapshot removed: " + name);
+        if (wasDefault) {
+            clearDefault(function () {
+                callback(null);
+            });
+        } else {
+            callback(null);
+        }
+    });
+}
+
+// Recover a snapshot from its /fabmo-def mirror into /opt. Used during
+// /opt-loss recovery: the engine boot sequence calls this after the
+// auto-profile has been applied and detects that the user previously
+// blessed a snapshot whose operational copy is no longer present.
+//
+// Steps:
+//   1. Overlay the mirror's config files onto /opt/fabmo/config
+//      (overwrite). Files in /opt absent from the mirror remain.
+//   2. Overlay the mirror's macros onto /opt/fabmo/macros.
+//   3. Re-populate /opt/fabmo_snapshots/<name>/ so the user has the
+//      same operational view as before /opt was wiped.
+//   4. Re-establish the in-/opt .default pointer.
+function recoverFromMirror(name, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (typeof name !== "string" || !name) {
+        return callback(new Error("Snapshot name required"));
+    }
+    var mirror = path.join(FABMO_DEF_SNAPSHOTS_DIR, name);
+    if (!fs.existsSync(mirror)) {
+        return callback(new Error("Mirror not found: " + mirror));
+    }
+    var mirrorConfig = path.join(mirror, "config");
+    var mirrorMacros = path.join(mirror, "macros");
+    var opSnapshot = snapshotPath(name);
+
+    var BACKUP_CONFIG_DIR = "/opt/fabmo_backup/config";
+    async.series(
+        [
+            function (cb) {
+                if (!fs.existsSync(mirrorConfig)) {
+                    return cb();
+                }
+                fs.ensureDir(LIVE_CONFIG_DIR, function (e) {
+                    if (e) {
+                        return cb(e);
+                    }
+                    fs.copy(mirrorConfig, LIVE_CONFIG_DIR, { overwrite: true }, cb);
+                });
+            },
+            function (cb) {
+                if (!fs.existsSync(mirrorMacros)) {
+                    return cb();
+                }
+                fs.ensureDir(LIVE_MACROS_DIR, function (e) {
+                    if (e) {
+                        return cb(e);
+                    }
+                    fs.copy(mirrorMacros, LIVE_MACROS_DIR, { overwrite: true }, cb);
+                });
+            },
+            function (cb) {
+                fs.ensureDir(SNAPSHOT_DIR, function (e) {
+                    if (e) {
+                        return cb(e);
+                    }
+                    fs.copy(mirror, opSnapshot, { overwrite: true }, cb);
+                });
+            },
+            // Keep the auto-backup mirror aligned with the snapshot we
+            // just restored. Otherwise the mirror retains whatever
+            // content was written there during the pre-recovery boot
+            // (typically profile defaults), and a config corruption
+            // between now and the next save would have the corruption
+            // recovery chain return that stale content instead of
+            // falling through to the snapshot tier.
+            function (cb) {
+                if (!fs.existsSync(mirrorConfig)) {
+                    return cb();
+                }
+                fs.ensureDir(BACKUP_CONFIG_DIR, function (e) {
+                    if (e) {
+                        return cb(e);
+                    }
+                    fs.copy(mirrorConfig, BACKUP_CONFIG_DIR, { overwrite: true }, cb);
+                });
+            },
+            function (cb) {
+                fs.writeFile(DEFAULT_POINTER, name, cb);
+            },
+        ],
+        function (err) {
+            if (err) {
+                log.warn("recoverFromMirror failed for " + name + ": " + err.message);
+                return callback(err);
+            }
+            log.info("recovered user-default snapshot from mirror: " + name);
+            callback(null);
+        }
+    );
+}
+
+module.exports = {
+    create: create,
+    createAuto: createAuto,
+    list: list,
+    restore: restore,
+    remove: remove,
+    getDefault: getDefault,
+    setDefault: setDefault,
+    clearDefault: clearDefault,
+    snapshotPath: snapshotPath,
+    recoverFromMirror: recoverFromMirror,
+};


### PR DESCRIPTION
Reworks the machine-configuration system so customers have an explicit, named restore point and so /opt loss can recover the user's tuned state rather than only the shipped profile.

Backup mirror (config/config.js)
- Mirror /opt/fabmo/config/<name>.json to /opt/fabmo_backup/config/ synchronously on every Config.save() (atomic tmp + rename, JSON-validated by re-parse). Eliminates the drift / stale-backup failure mode where the chokidar watcher's idle-only + 30s spacing + 5-min abandon rule could leave the backup pointing at pre-tune state for hours.
- Add a rotating per-config history under /opt/fabmo_backup/config_history/ with the 10 most recent saves, so a corruption that produces valid JSON can be rolled back beyond just the latest mirror.

Transparent recovery (config/recovery_log.js, config/config.js)
- New persistent recovery_log writes JSON-lines events to /opt/fabmo_backup/recovery.log and copies the corrupt source file to /opt/fabmo_backup/corrupt/<ts>-<name> for post-mortem.
- Config.load() fallback chain now records which tier won (backup, user-default snapshot, working profile, original profile, or failed).
- New API: GET /config/recovery-events (with ?unacknowledged=1 filter) and POST /config/recovery-events/acknowledge.

User-default snapshots (snapshots.js, routes/config.js)
- New /fabmo/snapshots.js module: create, list, restore, remove plus an auto-snapshot helper. User-named snapshots restricted to [a-zA-Z0-9_-]{1,25} (excluding reserved auto-prefixes). instance.json, auth_secret, and dotfiles are excluded. Auto-snapshot kinds rotate to the 5 most recent each.
- Auto-snapshot at the start of profiles.apply() (auto_pre_profile) and inside snapshots.restore() (auto_pre_restore) so accidental destructive transitions stay reversible.
- New API: GET /snapshots, POST /snapshots, POST /snapshots/:name/restore, DELETE /snapshots/:name, POST /snapshots/:name/set-default, POST /snapshots/clear-default.
- setDefault inserts the snapshot into the corruption-recovery chain between auto-backup mirror and working profile.

Cross-/opt-loss persistence (snapshots.js, config/profile_definition.js)
- The blessed snapshot mirrors to /fabmo-def/snapshots/<name>/ on setDefault and clears on clearDefault, so the user's restore floor survives a wipe of /opt.
- profile_definition.js gains atomic write helpers: setProfileName, setSnapshotName, clearSnapshotName, with read() accepting either as a valid recovery target.

/opt-loss recovery (engine.js, snapshots.js)
- snapshots.recoverFromMirror() rehydrates /opt from /fabmo-def: live config, live macros, /opt/fabmo_snapshots/<name>/, /opt/fabmo_backup/ config/, and the .default pointer all become coherent in one step.
- engine.js apply_auto_profile_if_needed detects fresh /opt (snapshot_name set + mirror exists + .default pointer absent) and runs recoverFromMirror after the profile is applied, then forces a clean restart. cleanupPreAutoProfileBackup is invoked afterwards so the dashboard's separate pre-auto-profile restore modal doesn't race.

Profile change tracking (routes/config.js)
- Manual profile change now updates fabmo-def.profile_name (directory-name form via Config.resolveProfileDirectory) and clears any blessed snapshot, so changing profile supersedes the old user-default. Bookkeeping runs BEFORE config.engine.set because EngineConfig.update calls profiles.apply then process.exit(1) without returning control.

Configuration app UI (dashboard/apps/configuration.fma)
- New "My Default Settings" section with "Save current settings as my default" and "Reset to my default settings" buttons plus a current-default indicator. Uses an inline modal (the app's sandboxed iframe blocks window.prompt). Save flow: snapshot create + set-default. Reset flow: confirms via fabmo.showModal, calls /snapshots/:name/restore which takes an auto_pre_restore snapshot first and restarts the engine.

systemd unit (files/fabmo.service)
- Revert Restart=on-failure to Restart=always (the historical setting before commit 74a30410 in Dec 2025). Every in-process exit flow - snapshot restore, manual profile change, backup restore - relies on systemd bringing the engine back. Adds StartLimitBurst=5 / StartLimitIntervalSec=60 as a safety net against runaway restart loops.