### PR TITLE
Move previewer material rendering to a Web Worker

### DIFF
--- a/dashboard/apps/previewer.fma/js/material.js
+++ b/dashboard/apps/previewer.fma/js/material.js
@@ -53,6 +53,38 @@ module.exports = function(scene, update) {
   // Shade range: deepest cut renders at depthMin, uncut top at 1.0.
   var depthMin = 0.15;
 
+  // Web Worker that builds the initial uncut mesh off the main thread. Created
+  // lazily on first use; null if Worker isn't supported (in which case we fall
+  // back to the synchronous path inline). The worker source is imported as a
+  // raw string (webpack 'asset/source' rule) and wrapped in a Blob URL so we
+  // don't rely on webpack's import.meta.url worker syntax (which doesn't parse
+  // cleanly inside CommonJS modules like this one).
+  var workerSource = require('./material.worker.js');
+  var _worker = null;
+  var _workerBlobUrl = null;
+  // Monotonic id stamped on each worker job; the main thread only accepts a
+  // response whose jobId matches the most recent dispatch.
+  var _workerJobId = 0;
+  function ensureWorker() {
+    if (_worker) return _worker;
+    if (typeof Worker === 'undefined' || typeof Blob === 'undefined') return null;
+    try {
+      if (!_workerBlobUrl) {
+        var blob = new Blob([workerSource], { type: 'application/javascript' });
+        _workerBlobUrl = URL.createObjectURL(blob);
+      }
+      _worker = new Worker(_workerBlobUrl);
+      _worker.onerror = function (err) {
+        console.warn('Material worker error — future builds will fall back to sync:', err);
+        _worker = null;
+      };
+    } catch (e) {
+      console.warn('Material worker unavailable, falling back to sync build:', e);
+      _worker = null;
+    }
+    return _worker;
+  }
+
   /**
    * Helper to properly dispose a mesh and track its resources
    */
@@ -101,9 +133,16 @@ module.exports = function(scene, update) {
   }
 
   /**
-   * Initialize material block with height map
+   * Initialize material block with height map.
+   *
+   * The heavy fill of top vertices + indices + colors for the initial uncut
+   * mesh is dispatched to a Web Worker; that step is what locks the UI on
+   * low-performance systems. Bottom vertices are still filled inline (small
+   * loop, fast). The optional `onDone` callback fires after the mesh has
+   * been added to the scene. If Workers aren't available, the build runs
+   * synchronously and `onDone` fires before initialize returns.
    */
-  self.initialize = function(pathBounds, height, diameter, topZ) {
+  self.initialize = function(pathBounds, height, diameter, topZ, onDone) {
     var t0 = performance.now();
     // CHANGED: Just dispose old meshes, don't destroy everything
     self.mesh = disposeMesh(self.mesh);
@@ -182,9 +221,104 @@ module.exports = function(scene, update) {
                 'Stock:', stockHeight, 'TopZ:', materialTop, 'Tool:', toolDia,
                 'Verts:', totalVerts, 'MaxFaces:', maxFaces);
 
-    // Create initial mesh
-    self.createFullMesh();
+    // Build the initial uncut mesh (worker-dispatched when supported).
+    _buildInitialMeshAsync(onDone);
   };
+
+  /**
+   * Build the initial uncut mesh. Dispatches the heavy fill (top vertices,
+   * indices, colors) to material.worker.js when available, falling back to
+   * the synchronous createFullMesh path otherwise. The pre-allocated
+   * posArr / colorArr / idxArr are transferred to the worker and back to
+   * avoid copying; nothing else may touch them while the job is in flight,
+   * which is fine because initialize() is only called from a file-load path.
+   */
+  function _buildInitialMeshAsync(onDone) {
+    if (!heightMap || !posArr) {
+      if (onDone) onDone();
+      return;
+    }
+
+    var worker = ensureWorker();
+    if (!worker) {
+      // Sync fallback — original path.
+      self.createFullMesh();
+      if (onDone) onDone();
+      return;
+    }
+
+    var thisJob = ++_workerJobId;
+    var tStart = performance.now();
+
+    var onMsg = function (e) {
+      if (!e.data || e.data.jobId !== thisJob) return;
+      if (e.data.type !== 'buildUncutDone') return;
+      worker.removeEventListener('message', onMsg);
+
+      // Worker transferred the buffers back — rebind closure refs.
+      posArr = new Float32Array(e.data.posBuf);
+      colorArr = new Float32Array(e.data.colorBuf);
+      idxArr = new Uint32Array(e.data.idxBuf);
+      topVertCount = e.data.topVertCount;
+      botVertOffset = e.data.botVertOffset;
+
+      // Construct THREE.js geometry + mesh on the main thread.
+      var geometry = new THREE.BufferGeometry();
+      posAttr = new THREE.BufferAttribute(posArr, 3);
+      colorAttr = new THREE.BufferAttribute(colorArr, 3);
+      idxAttr = new THREE.BufferAttribute(idxArr, 1);
+      geometry.setAttribute('position', posAttr);
+      geometry.setAttribute('color', colorAttr);
+      geometry.setIndex(idxAttr);
+      geometry.setDrawRange(0, e.data.indexCount);
+      geometry.computeBoundingSphere();
+      activeGeometries.push(geometry);
+
+      if (!meshMaterial) {
+        meshMaterial = new THREE.MeshPhongMaterial({
+          vertexColors: true,
+          flatShading: true,
+          shininess: 0,
+          side: THREE.DoubleSide
+        });
+        activeMaterials.push(meshMaterial);
+      }
+
+      self.mesh = new THREE.Mesh(geometry, meshMaterial);
+      self.mesh.visible = !!self.show;
+      scene.add(self.mesh);
+
+      geometryCreated = true;
+      console.log('createFullMesh (worker): ' + (performance.now() - tStart).toFixed(0) + 'ms');
+      update();
+      if (onDone) onDone();
+    };
+
+    worker.addEventListener('message', onMsg);
+    worker.postMessage(
+      {
+        type: 'buildUncut',
+        jobId: thisJob,
+        params: {
+          xPoints: heightMap.xPoints,
+          yPoints: heightMap.yPoints,
+          xStep: heightMap.xStep,
+          yStep: heightMap.yStep,
+          boundsMinX: bounds.min.x,
+          boundsMinY: bounds.min.y,
+          materialTop: materialTop,
+          baseColor: baseColor,
+          depthMin: depthMin
+        },
+        posBuf: posArr.buffer,
+        colorBuf: colorArr.buffer,
+        idxBuf: idxArr.buffer
+      },
+      [posArr.buffer, colorArr.buffer, idxArr.buffer]
+    );
+    // After transfer, posArr/colorArr/idxArr in this scope are detached
+    // (length 0). They get rebound when the worker responds.
+  }
 
   /**
    * Get grid indices from world coordinates
@@ -502,6 +636,55 @@ module.exports = function(scene, update) {
     if (!heightMap || !segments.length) { if (onDone) onDone(); return; }
     var t0 = performance.now();
 
+    // Worker path: dispatch the per-cell minZ computation off the main
+    // thread so orbit/rotate stays smooth during the "Computing material…"
+    // phase. The heights Float32Array is transferred to the worker and
+    // rebound onto the heightMap when the worker responds. Falls through
+    // to the inline sync code below if Worker isn't available.
+    var worker = ensureWorker();
+    if (worker) {
+      var thisJob = ++_workerJobId;
+      var heightsBufIn = heightMap.heights.buffer;
+      var onMsg = function (e) {
+        if (!e.data || e.data.jobId !== thisJob) return;
+        if (e.data.type === 'progress') {
+          if (onProgress) onProgress(e.data.frac);
+          return;
+        }
+        if (e.data.type !== 'computeHeightsDone') return;
+        worker.removeEventListener('message', onMsg);
+        heightMap.heights = new Float32Array(e.data.heightsBuf);
+        isDirty = e.data.cutCount > 0;
+        pendingUpdates = e.data.cutCount;
+        console.log('computeFromSegmentsAsync (worker): ' + segments.length +
+                    ' segments, ' + e.data.cutCount + ' cells cut, total=' +
+                    (performance.now() - t0).toFixed(0) + 'ms');
+        if (onDone) onDone();
+      };
+      worker.addEventListener('message', onMsg);
+      worker.postMessage(
+        {
+          type: 'computeHeights',
+          jobId: thisJob,
+          params: {
+            xPoints: heightMap.xPoints,
+            yPoints: heightMap.yPoints,
+            xStep: heightMap.xStep,
+            yStep: heightMap.yStep,
+            boundsMinX: bounds.min.x,
+            boundsMinY: bounds.min.y,
+            boundsMaxX: bounds.max.x,
+            boundsMaxY: bounds.max.y,
+            materialTop: materialTop,
+          },
+          segments: segments,
+          heightsBuf: heightsBufIn,
+        },
+        [heightsBufIn]
+      );
+      return;
+    }
+
     var xP = heightMap.xPoints;
     var yP = heightMap.yPoints;
     var xS = heightMap.xStep;
@@ -553,65 +736,74 @@ module.exports = function(scene, update) {
       }
     }
 
-    // Process rows in batches
+    // Process rows in time-bounded batches: each batch runs until ~16ms of
+    // wall-clock has elapsed, then yields via setTimeout(0). Adapts to job
+    // complexity — dense jobs naturally shrink batches; sparse stay fast.
+    // The prior fixed-batch scheme (yP/20 rows) was too coarse on slower
+    // browsers (e.g. Safari): a single batch could lock the main thread for
+    // seconds. ~16ms keeps things visibly fluid at ~60fps.
     var rowPos = 0;
-    var rowsPerBatch = Math.max(1, Math.floor(yP / 20)); // ~20 progress steps
     var cutCount = 0;
+    var BATCH_BUDGET_MS = 16;
 
     function processBatch() {
-      var rowEnd = Math.min(rowPos + rowsPerBatch, yP);
-      for (var yi = rowPos; yi < rowEnd; yi++) {
+      var batchStart = performance.now();
+      while (rowPos < yP) {
+        var yi = rowPos;
         var py = minY + yi * yS;
         var gyy = Math.floor((py - minY) / cellSize);
-        if (gyy < 0 || gyy >= gridH) continue;
+        if (gyy >= 0 && gyy < gridH) {
+          for (var xi = 0; xi < xP; xi++) {
+            var px = minX + xi * xS;
+            var gx = Math.floor((px - minX) / cellSize);
+            if (gx < 0 || gx >= gridW) continue;
+            var cell = grid[gridKey(gx, gyy)];
+            if (!cell) continue;
 
-        for (var xi = 0; xi < xP; xi++) {
-          var px = minX + xi * xS;
-          var gx = Math.floor((px - minX) / cellSize);
-          if (gx < 0 || gx >= gridW) continue;
-          var cell = grid[gridKey(gx, gyy)];
-          if (!cell) continue;
-
-          var minZ = materialTop;
-          for (var s = 0; s < cell.length; s++) {
-            var seg = segments[cell[s]];
-            var ssx = seg.start, eex = seg.end;
-            var dx = eex[0] - ssx[0];
-            var dy = eex[1] - ssx[1];
-            var lenSq = dx * dx + dy * dy;
-            var t;
-            if (lenSq < 0.000001) { t = 0; }
-            else {
-              t = ((px - ssx[0]) * dx + (py - ssx[1]) * dy) / lenSq;
-              if (t < 0) t = 0; else if (t > 1) t = 1;
+            var minZ = materialTop;
+            for (var s = 0; s < cell.length; s++) {
+              var seg = segments[cell[s]];
+              var ssx = seg.start, eex = seg.end;
+              var dx = eex[0] - ssx[0];
+              var dy = eex[1] - ssx[1];
+              var lenSq = dx * dx + dy * dy;
+              var t;
+              if (lenSq < 0.000001) { t = 0; }
+              else {
+                t = ((px - ssx[0]) * dx + (py - ssx[1]) * dy) / lenSq;
+                if (t < 0) t = 0; else if (t > 1) t = 1;
+              }
+              var cx = ssx[0] + t * dx;
+              var cy = ssx[1] + t * dy;
+              var cz = ssx[2] + t * (eex[2] - ssx[2]);
+              var dist = Math.sqrt((px - cx) * (px - cx) + (py - cy) * (py - cy));
+              var segRadius = seg.toolDia / 2;
+              var z;
+              if (seg.toolType === 'vbit') {
+                var tanHalf = Math.tan((seg.vbitAngle / 2) * Math.PI / 180);
+                z = cz + dist / tanHalf;
+                if (z >= materialTop) continue;
+              } else if (seg.toolType === 'ball') {
+                if (dist > segRadius) continue;
+                z = cz + segRadius - Math.sqrt(segRadius * segRadius - dist * dist);
+              } else {
+                if (dist > segRadius) continue;
+                z = cz;
+              }
+              if (z < minZ) minZ = z;
             }
-            var cx = ssx[0] + t * dx;
-            var cy = ssx[1] + t * dy;
-            var cz = ssx[2] + t * (eex[2] - ssx[2]);
-            var dist = Math.sqrt((px - cx) * (px - cx) + (py - cy) * (py - cy));
-            var segRadius = seg.toolDia / 2;
-            var z;
-            if (seg.toolType === 'vbit') {
-              var tanHalf = Math.tan((seg.vbitAngle / 2) * Math.PI / 180);
-              z = cz + dist / tanHalf;
-              if (z >= materialTop) continue;
-            } else if (seg.toolType === 'ball') {
-              if (dist > segRadius) continue;
-              z = cz + segRadius - Math.sqrt(segRadius * segRadius - dist * dist);
-            } else {
-              if (dist > segRadius) continue;
-              z = cz;
+            if (minZ < materialTop) {
+              heights[yi * xP + xi] = minZ;
+              cutCount++;
             }
-            if (z < minZ) minZ = z;
-          }
-          if (minZ < materialTop) {
-            heights[yi * xP + xi] = minZ;
-            cutCount++;
           }
         }
+        rowPos++;
+        // Time-based yield: check after each row to keep the UI responsive
+        // on slower browsers without bloating overhead on fast ones.
+        if (performance.now() - batchStart >= BATCH_BUDGET_MS) break;
       }
 
-      rowPos = rowEnd;
       if (onProgress) onProgress(rowPos / yP);
 
       if (rowPos < yP) {

--- a/dashboard/apps/previewer.fma/js/material.worker.js
+++ b/dashboard/apps/previewer.fma/js/material.worker.js
@@ -1,0 +1,268 @@
+/**
+ * Material mesh worker.
+ *
+ * Off-main-thread builder for the initial uncut stepped-column mesh. The
+ * caller transfers pre-allocated posArr / colorArr / idxArr buffers in,
+ * along with the grid parameters; the worker fills the top vertices, all
+ * indices, and per-vertex colors, then transfers the buffers back.
+ *
+ * Only the *initial* uncut mesh build runs here today — that's the path
+ * that locks the UI on low-performance systems. Subsequent rebuilds during
+ * and after cut application still run on the main thread (smaller work,
+ * needs the live heightMap).
+ *
+ * Bottom vertices are filled by the main thread before transfer; the
+ * worker does not touch them.
+ */
+
+'use strict';
+
+self.onmessage = function (e) {
+    var msg = e.data;
+    if (!msg) return;
+
+    if (msg.type === 'buildUncut') {
+        var p = msg.params;
+        var posArr = new Float32Array(msg.posBuf);
+        var colorArr = new Float32Array(msg.colorBuf);
+        var idxArr = new Uint32Array(msg.idxBuf);
+
+        var indexCount = buildUncut(p, posArr, colorArr, idxArr);
+
+        self.postMessage(
+            {
+                type: 'buildUncutDone',
+                jobId: msg.jobId,
+                posBuf: posArr.buffer,
+                colorBuf: colorArr.buffer,
+                idxBuf: idxArr.buffer,
+                indexCount: indexCount,
+                topVertCount: p.xPoints * p.yPoints * 4,
+                botVertOffset: p.xPoints * p.yPoints * 4,
+            },
+            [posArr.buffer, colorArr.buffer, idxArr.buffer]
+        );
+        return;
+    }
+
+    if (msg.type === 'computeHeights') {
+        var heights = new Float32Array(msg.heightsBuf);
+        var jobId = msg.jobId;
+        var cutCount = computeHeights(msg.params, msg.segments, heights, function (frac) {
+            self.postMessage({ type: 'progress', jobId: jobId, frac: frac });
+        });
+        self.postMessage(
+            {
+                type: 'computeHeightsDone',
+                jobId: jobId,
+                heightsBuf: heights.buffer,
+                cutCount: cutCount,
+            },
+            [heights.buffer]
+        );
+        return;
+    }
+};
+
+function buildUncut(p, posArr, colorArr, idxArr) {
+    var xPoints = p.xPoints;
+    var yPoints = p.yPoints;
+    var xStep = p.xStep;
+    var yStep = p.yStep;
+    var minX = p.boundsMinX;
+    var minY = p.boundsMinY;
+    var materialTop = p.materialTop;
+    var baseColor = p.baseColor;
+    var depthMin = p.depthMin;
+
+    var topVertCount = xPoints * yPoints * 4;
+    var botVertOffset = topVertCount;
+    var hw = xStep / 2;
+    var hh = yStep / 2;
+
+    // --- Top vertices (all at materialTop for an uncut mesh) -----------------
+    for (var yi = 0; yi < yPoints; yi++) {
+        for (var xi = 0; xi < xPoints; xi++) {
+            var base = (yi * xPoints + xi) * 4 * 3;
+            var cx = minX + xi * xStep;
+            var cy = minY + yi * yStep;
+            posArr[base]      = cx - hw; posArr[base + 1]  = cy - hh; posArr[base + 2]  = materialTop;
+            posArr[base + 3]  = cx + hw; posArr[base + 4]  = cy - hh; posArr[base + 5]  = materialTop;
+            posArr[base + 6]  = cx - hw; posArr[base + 7]  = cy + hh; posArr[base + 8]  = materialTop;
+            posArr[base + 9]  = cx + hw; posArr[base + 10] = cy + hh; posArr[base + 11] = materialTop;
+        }
+    }
+
+    // --- Indices: top + bottom + outer walls (no internal walls — flat) ------
+    var fi = 0;
+    function tv(xi, yi, c) { return (yi * xPoints + xi) * 4 + c; }
+    function bv(xi, yi) { return botVertOffset + yi * (xPoints + 1) + xi; }
+
+    // Top faces
+    for (yi = 0; yi < yPoints; yi++) {
+        for (xi = 0; xi < xPoints; xi++) {
+            idxArr[fi++] = tv(xi, yi, 0); idxArr[fi++] = tv(xi, yi, 1); idxArr[fi++] = tv(xi, yi, 2);
+            idxArr[fi++] = tv(xi, yi, 1); idxArr[fi++] = tv(xi, yi, 3); idxArr[fi++] = tv(xi, yi, 2);
+        }
+    }
+    // Bottom faces
+    for (yi = 0; yi < yPoints; yi++) {
+        for (xi = 0; xi < xPoints; xi++) {
+            idxArr[fi++] = bv(xi, yi);     idxArr[fi++] = bv(xi, yi + 1); idxArr[fi++] = bv(xi + 1, yi);
+            idxArr[fi++] = bv(xi + 1, yi); idxArr[fi++] = bv(xi, yi + 1); idxArr[fi++] = bv(xi + 1, yi + 1);
+        }
+    }
+    // Outer walls — front (yi=0)
+    for (xi = 0; xi < xPoints; xi++) {
+        idxArr[fi++] = bv(xi, 0);    idxArr[fi++] = tv(xi, 0, 0); idxArr[fi++] = bv(xi + 1, 0);
+        idxArr[fi++] = tv(xi, 0, 0); idxArr[fi++] = tv(xi, 0, 1); idxArr[fi++] = bv(xi + 1, 0);
+    }
+    // Back (yi=yP-1)
+    for (xi = 0; xi < xPoints; xi++) {
+        idxArr[fi++] = tv(xi, yPoints - 1, 2); idxArr[fi++] = bv(xi, yPoints);     idxArr[fi++] = tv(xi, yPoints - 1, 3);
+        idxArr[fi++] = tv(xi, yPoints - 1, 3); idxArr[fi++] = bv(xi, yPoints);     idxArr[fi++] = bv(xi + 1, yPoints);
+    }
+    // Left (xi=0)
+    for (yi = 0; yi < yPoints; yi++) {
+        idxArr[fi++] = tv(0, yi, 0); idxArr[fi++] = bv(0, yi);     idxArr[fi++] = tv(0, yi, 2);
+        idxArr[fi++] = tv(0, yi, 2); idxArr[fi++] = bv(0, yi);     idxArr[fi++] = bv(0, yi + 1);
+    }
+    // Right (xi=xP-1)
+    for (yi = 0; yi < yPoints; yi++) {
+        idxArr[fi++] = bv(xPoints, yi);           idxArr[fi++] = tv(xPoints - 1, yi, 1); idxArr[fi++] = bv(xPoints, yi + 1);
+        idxArr[fi++] = tv(xPoints - 1, yi, 1);    idxArr[fi++] = tv(xPoints - 1, yi, 3); idxArr[fi++] = bv(xPoints, yi + 1);
+    }
+
+    // --- Colors: top of stock at full base color; bottom at depthMin --------
+    var topColorBytes = topVertCount * 3;
+    for (var i = 0; i < topColorBytes; i += 3) {
+        colorArr[i]     = baseColor.r;
+        colorArr[i + 1] = baseColor.g;
+        colorArr[i + 2] = baseColor.b;
+    }
+    for (i = botVertOffset * 3; i < colorArr.length; i += 3) {
+        colorArr[i]     = baseColor.r * depthMin;
+        colorArr[i + 1] = baseColor.g * depthMin;
+        colorArr[i + 2] = baseColor.b * depthMin;
+    }
+
+    return fi;
+}
+
+/**
+ * Compute the per-cell minimum-Z heightmap from a list of tool segments.
+ * Mirrors the math in material.js computeFromSegmentsAsync; runs straight
+ * through here because we're off the main thread. Posts progress roughly
+ * every PROGRESS_ROW_INTERVAL rows so the main thread can paint the bar.
+ */
+function computeHeights(p, segments, heights, onProgress) {
+    var xP = p.xPoints, yP = p.yPoints;
+    var xS = p.xStep, yS = p.yStep;
+    var minX = p.boundsMinX, minY = p.boundsMinY;
+    var maxX = p.boundsMaxX, maxY = p.boundsMaxY;
+    var materialTop = p.materialTop;
+
+    // Spatial grid bucket — identical to main-thread version.
+    var maxInfluence = 0;
+    for (var i = 0; i < segments.length; i++) {
+        var seg = segments[i];
+        var r = seg.toolDia / 2;
+        if (seg.toolType === 'vbit') {
+            var maxDepth = Math.max(
+                Math.abs(seg.start[2] - materialTop),
+                Math.abs(seg.end[2] - materialTop)
+            );
+            var angleRad = (seg.vbitAngle / 2) * Math.PI / 180;
+            r = Math.max(r, maxDepth * Math.tan(angleRad));
+        }
+        if (r > maxInfluence) maxInfluence = r;
+    }
+    maxInfluence += Math.max(xS, yS);
+    var cellSize = Math.max(maxInfluence * 2, Math.max(xS, yS) * 4);
+    var gridW = Math.ceil((maxX - minX) / cellSize) + 1;
+    var gridH = Math.ceil((maxY - minY) / cellSize) + 1;
+    var grid = new Array(gridW * gridH);
+    for (i = 0; i < grid.length; i++) grid[i] = null;
+
+    for (i = 0; i < segments.length; i++) {
+        seg = segments[i];
+        var sx = seg.start, ex = seg.end;
+        var x0 = Math.min(sx[0], ex[0]) - maxInfluence;
+        var x1 = Math.max(sx[0], ex[0]) + maxInfluence;
+        var y0 = Math.min(sx[1], ex[1]) - maxInfluence;
+        var y1 = Math.max(sx[1], ex[1]) + maxInfluence;
+        var gx0 = Math.max(0, Math.floor((x0 - minX) / cellSize));
+        var gx1 = Math.min(gridW - 1, Math.floor((x1 - minX) / cellSize));
+        var gy0 = Math.max(0, Math.floor((y0 - minY) / cellSize));
+        var gy1 = Math.min(gridH - 1, Math.floor((y1 - minY) / cellSize));
+        for (var gy = gy0; gy <= gy1; gy++) {
+            for (var gx = gx0; gx <= gx1; gx++) {
+                var k = gy * gridW + gx;
+                if (!grid[k]) grid[k] = [];
+                grid[k].push(i);
+            }
+        }
+    }
+
+    var cutCount = 0;
+    // Coarse-grained progress posting: yP/20 rows or every 32 rows minimum.
+    var progressInterval = Math.max(32, Math.floor(yP / 20));
+    var rowsSinceProgress = 0;
+
+    for (var yi = 0; yi < yP; yi++) {
+        var py = minY + yi * yS;
+        var gyy = Math.floor((py - minY) / cellSize);
+        if (gyy >= 0 && gyy < gridH) {
+            for (var xi = 0; xi < xP; xi++) {
+                var px = minX + xi * xS;
+                var gxx = Math.floor((px - minX) / cellSize);
+                if (gxx < 0 || gxx >= gridW) continue;
+                var cell = grid[gyy * gridW + gxx];
+                if (!cell) continue;
+
+                var minZ = materialTop;
+                for (var s = 0; s < cell.length; s++) {
+                    seg = segments[cell[s]];
+                    var ssx = seg.start, eex = seg.end;
+                    var dx = eex[0] - ssx[0];
+                    var dy = eex[1] - ssx[1];
+                    var lenSq = dx * dx + dy * dy;
+                    var t;
+                    if (lenSq < 0.000001) { t = 0; }
+                    else {
+                        t = ((px - ssx[0]) * dx + (py - ssx[1]) * dy) / lenSq;
+                        if (t < 0) t = 0; else if (t > 1) t = 1;
+                    }
+                    var cx = ssx[0] + t * dx;
+                    var cy = ssx[1] + t * dy;
+                    var cz = ssx[2] + t * (eex[2] - ssx[2]);
+                    var dist = Math.sqrt((px - cx) * (px - cx) + (py - cy) * (py - cy));
+                    var segRadius = seg.toolDia / 2;
+                    var z;
+                    if (seg.toolType === 'vbit') {
+                        var tanHalf = Math.tan((seg.vbitAngle / 2) * Math.PI / 180);
+                        z = cz + dist / tanHalf;
+                        if (z >= materialTop) continue;
+                    } else if (seg.toolType === 'ball') {
+                        if (dist > segRadius) continue;
+                        z = cz + segRadius - Math.sqrt(segRadius * segRadius - dist * dist);
+                    } else {
+                        if (dist > segRadius) continue;
+                        z = cz;
+                    }
+                    if (z < minZ) minZ = z;
+                }
+                if (minZ < materialTop) {
+                    heights[yi * xP + xi] = minZ;
+                    cutCount++;
+                }
+            }
+        }
+        if (++rowsSinceProgress >= progressInterval) {
+            rowsSinceProgress = 0;
+            if (onProgress) onProgress((yi + 1) / yP);
+        }
+    }
+    if (onProgress) onProgress(1);
+    return cutCount;
+}

--- a/dashboard/apps/previewer.fma/js/viewer.js
+++ b/dashboard/apps/previewer.fma/js/viewer.js
@@ -444,19 +444,24 @@ module.exports = function(container) {
       return;
     }
     var p = self._materialParams;
-    self.material.initialize(p.bounds, p.thickness, p.toolDia, p.materialTop);
-    // Sync the current light direction into the freshly-built mesh's hillshade.
-    applyLightDirectionToMaterial();
-    self.gui.showLoading('Computing material\u2026');
-    self.path.applyAllMaterial(
-      function(progress) {
-        var pct = Math.round(progress * 100);
-        self.gui.showLoading('Computing material\u2026 <progress max="100" value="' + pct + '"></progress>');
-      },
-      function() {
-        if (onDone) onDone();
-      }
-    );
+    // Show the loading message immediately so the user gets feedback while
+    // the worker builds the initial uncut mesh (previously the UI froze with
+    // no indication). initialize is now async; chain the rest in its callback.
+    self.gui.showLoading('Preparing material\u2026');
+    self.material.initialize(p.bounds, p.thickness, p.toolDia, p.materialTop, function () {
+      // Sync the current light direction into the freshly-built mesh's hillshade.
+      applyLightDirectionToMaterial();
+      self.gui.showLoading('Computing material\u2026');
+      self.path.applyAllMaterial(
+        function(progress) {
+          var pct = Math.round(progress * 100);
+          self.gui.showLoading('Computing material\u2026 <progress max="100" value="' + pct + '"></progress>');
+        },
+        function() {
+          if (onDone) onDone();
+        }
+      );
+    });
   }
 
   // Assign toolInfo from operations to each move based on sourceLine ranges.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,14 @@ var config = {
                 test: /\.(eot|otf|svg|ttf|woff|woff2|png|jpg|gif|pdf)$/,
                 type: "asset",
             },
+            {
+                // Web Worker sources: import as raw string so the main module
+                // can wrap them in a Blob URL and instantiate the Worker. This
+                // avoids relying on webpack's import.meta.url worker syntax,
+                // which doesn't parse cleanly in CommonJS modules.
+                test: /\.worker\.js$/,
+                type: "asset/source",
+            },
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/


### PR DESCRIPTION
The initial uncut stepped-column mesh build and the per-cell minimum-Z heightmap computation both ran on the main thread, locking the preview UI on slower browsers (notably Safari) while loading material.

Both passes now run in dashboard/apps/previewer.fma/js/material.worker.js, with the heights / position / color / index buffers transferred in and out to avoid copies. Worker progress messages drive the loading bar so orbit and pan stay smooth during compute. Falls back to the existing synchronous path when Worker isn't available.

The previous fixed 1/20-of-rows batches in computeFromSegmentsAsync are replaced by ~16ms time-budgeted batches in the sync fallback. webpack imports the worker source as a raw string (asset/source) which we wrap in a Blob URL — avoids import.meta.url worker syntax that doesn't parse inside CommonJS modules.