### PR TITLE
Job Manager: move repeat to toolbar; add count modal; fix race

### DIFF
--- a/dashboard/apps/job_manager.fma/css/style.css
+++ b/dashboard/apps/job_manager.fma/css/style.css
@@ -1052,26 +1052,21 @@ table {
 }
 
 
-/* Repeat-mode toggle button on the next-in-queue card.
-   Sits just below the play button (bottom-right of the radial), fully clear
-   of the 100x100 play circle. Click toggles persistent server-side repeat. */
+/* Repeat-mode toggle button — lives inline with preview/ghost/edit in the
+   icon-row of the next-in-queue card. Click opens a modal where the operator
+   sets a count (blank = run until canceled). The optional .on class turns the
+   icon green; the .repeat-count-badge shows the remaining run count. */
 .repeat-button {
-  position: absolute;
-  top: 78px;
-  right: 34px;
-  width: 30px;
-  height: 30px;
-  line-height: 30px;
-  text-align: center;
+  position: relative;
+  display: inline-block;
   color: #888;
   cursor: pointer;
-  border-radius: 50%;
-  z-index: 51;
-  transition: color 0.2s, background-color 0.2s;
+  transition: color 0.2s;
 }
 
 .repeat-button i {
-  font-size: 20px;
+  font-size: 22px;
+  line-height: 1;
 }
 
 .repeat-button:hover {
@@ -1084,6 +1079,27 @@ table {
 
 .repeat-button.on:hover {
   color: #1f8a1f;
+}
+
+.repeat-count-badge {
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  background: #32B433;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 16px;
+  text-align: center;
+  border-radius: 8px;
+  display: none;
+}
+
+.repeat-count-badge.visible {
+  display: inline-block;
 }
 
 /* Ghost-run button sits inline with preview/edit/download/cancel in the

--- a/dashboard/apps/job_manager.fma/index.html
+++ b/dashboard/apps/job_manager.fma/index.html
@@ -23,6 +23,24 @@
 		</div>
 		<a class="close-reveal-modal" id="close-ghost-modal">&#215;</a>
 	</div>
+
+	<div id="repeat-modal" class="reveal-modal small" data-reveal>
+		<div id="modal-title">Repeat Job</div>
+		<p>After this job finishes, requeue and run it again. Set a total run
+		count, or leave blank to repeat until you stop it manually.</p>
+		<div class="row">
+			<label for="repeat-count">Total times to run (blank = until canceled):</label>
+			<input id="repeat-count" type="number" step="1" min="1" placeholder="blank = unlimited" />
+		</div>
+		<div class="row">
+			<div class="right">
+				<button id="repeat-cancel" class="button radius secondary">Cancel</button>
+				<button id="repeat-off" class="button radius alert">Turn Off</button>
+				<button id="repeat-save" class="button radius success">Save</button>
+			</div>
+		</div>
+		<a class="close-reveal-modal" id="close-repeat-modal">&#215;</a>
+	</div>
 </head>
 <body>
   <div class="filter"></div>

--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -170,7 +170,7 @@ function createRecentMenu(id) {
 }
 
 function makeActions() {
-  var actions = '<div> <div class="small-2 medium-4 columns play-button" style="text-align:right;"> <div class="radial_progress"> <div class="percent_circle"> <div class="mask full"><div class="fill"></div></div><div class="mask half"><div class="fill"></div><div class="fill fix"> </div> </div> <div class="shadow"> </div> </div> <div class="inset"> <div id="run-next" class="play"><i class="fa fa-play" title="Start/Resume"></i></div> </div></div><a class="repeat-button" title="Toggle Repeat (re-run this job when it finishes)"><i class="fa fa-repeat"></i></a></div></div><div class="small-8 medium-12 icon-row" sortable="false"><div class="medium-1 small-2 columns"><a class="preview" title="Preview Job"><img  class="svg" src="css/images/visible9.svg"></a></div><div class="medium-1 small-2 columns"><a class="ghost-button" title="Ghost Run (dry-run with a Z lift)"><img class="svg" src="css/images/ghost.svg"></a></div><div class="medium-1 small-2 columns"><a class="edit" title="Edit Job"><img class="svg" src="images/edit_icon.png"></a></div><div class="medium-1 small-2 columns"><a class="download" title="Download Job as CNC File"><img  class="svg" src="css/images/download151.svg"></a></div><div class="medium-1 small-2 columns"><a class="cancel" title="Cancel Job"><img  class="svg" src="css/images/recycling10.svg"></a></div><div class="sm-1 columns"></div></div><div class="row"></div><div class="job-lights-container"><div class="job-status-light one off"><div class="job-status-indicator"></div></div><div class="job-status-light two off"><div class="job-status-indicator"></div></div><div class="job-status-light three off"><div class="job-status-indicator"></div></div></div>'
+  var actions = '<div> <div class="small-2 medium-4 columns play-button" style="text-align:right;"> <div class="radial_progress"> <div class="percent_circle"> <div class="mask full"><div class="fill"></div></div><div class="mask half"><div class="fill"></div><div class="fill fix"> </div> </div> <div class="shadow"> </div> </div> <div class="inset"> <div id="run-next" class="play"><i class="fa fa-play" title="Start/Resume"></i></div> </div></div></div><div class="small-8 medium-12 icon-row" sortable="false"><div class="medium-1 small-2 columns"><a class="preview" title="Preview Job"><img  class="svg" src="css/images/visible9.svg"></a></div><div class="medium-1 small-2 columns"><a class="repeat-button" title="Repeat Job (set a count or leave blank to repeat until canceled)"><i class="fa fa-repeat"></i><span class="repeat-count-badge"></span></a></div><div class="medium-1 small-2 columns"><a class="ghost-button" title="Ghost Run (dry-run with a Z lift)"><img class="svg" src="css/images/ghost.svg"></a></div><div class="medium-1 small-2 columns"><a class="edit" title="Edit Job"><img class="svg" src="images/edit_icon.png"></a></div><div class="medium-1 small-2 columns"><a class="download" title="Download Job as CNC File"><img  class="svg" src="css/images/download151.svg"></a></div><div class="medium-1 small-2 columns"><a class="cancel" title="Cancel Job"><img  class="svg" src="css/images/recycling10.svg"></a></div><div class="sm-1 columns"></div></div><div class="row"></div><div class="job-lights-container"><div class="job-status-light one off"><div class="job-status-indicator"></div></div><div class="job-status-light two off"><div class="job-status-indicator"></div></div><div class="job-status-light three off"><div class="job-status-indicator"></div></div></div>'
   return actions;
 }
 
@@ -295,11 +295,22 @@ function setFirstCard(job) {
   $('.repeat-button').data('id', firstId);
   $('.ghost-button').data('id', firstId);
 
-  // Reflect persisted repeat state on the toggle button
-  if (job && job.repeat) {
-    $('.repeat-button').addClass('on');
+  // Reflect persisted repeat state on the toggle button. Stash the count on
+  // the button so the modal can pre-fill it. Badge shows remaining count when
+  // finite; hidden when null (indefinite) or repeat off.
+  var repeatOn = !!(job && job.repeat);
+  var repeatCount =
+    job && (job.repeatCount === 0 || job.repeatCount)
+      ? parseInt(job.repeatCount, 10)
+      : null;
+  $('.repeat-button')
+    .toggleClass('on', repeatOn)
+    .data('repeat-count', repeatCount);
+  var $badge = $('.repeat-button .repeat-count-badge');
+  if (repeatOn && repeatCount !== null && isFinite(repeatCount)) {
+    $badge.text(repeatCount).addClass('visible');
   } else {
-    $('.repeat-button').removeClass('on');
+    $badge.text('').removeClass('visible');
   }
 
   // Ghost mode requires the OpenSBP runtime (transforms aren't applied to
@@ -977,22 +988,74 @@ var sortable = Sortable.create(el, {
 var current_job_id = 0;
 
 function bindRepeatToggle() {
+  // Click on the repeat button opens a Foundation reveal-modal where the
+  // operator picks "Off", or sets a count (blank = run until canceled). The
+  // server response refreshes the queue, which then updates the button class
+  // and count badge — so we don't bother with optimistic UI flips here.
+  //
+  // Save/Off resolve the target job at *click* time (not modal-open time):
+  // if the modal is left open across a clone-on-finish, the originally-
+  // captured job ID is already finished and its repeat flag is irrelevant —
+  // the running clone is the one we need to mutate. The queue refresh keeps
+  // `.repeat-button`'s data('id') pointed at the current running/next job.
+  function currentRepeatJobId() {
+    return $('.repeat-button').first().data('id') || null;
+  }
+
   $('#queue_table').on('click touchstart', '.repeat-button', function(e) {
     e.preventDefault();
     e.stopPropagation();
     var jobid = $(this).data('id') || $(this).closest('.job_item').attr('id');
     if (!jobid) return;
-    // Optimistic UI flip; server response is authoritative and will be
-    // reflected on the next queue refresh.
-    var willBeOn = !$(this).hasClass('on');
-    $(this).toggleClass('on', willBeOn);
-    fabmo.setJobRepeat(jobid, willBeOn, function(err) {
-      if (err) {
-        fabmo.notify('error', err);
-        // Roll back the optimistic flip
-        $('.repeat-button').toggleClass('on', !willBeOn);
+    var isOn = $(this).hasClass('on');
+    var count = $(this).data('repeat-count');
+    $('#repeat-count').val(
+      isOn && count !== null && count !== undefined && isFinite(count) ? count : ''
+    );
+    // Hide "Turn Off" when repeat is already off — only "Save" / "Cancel"
+    // make sense in that case.
+    $('#repeat-off').toggle(isOn);
+    $('#repeat-modal').foundation('reveal', 'open');
+    setTimeout(function() { $('#repeat-count').focus().select(); }, 100);
+  });
+
+  $('#repeat-save').on('click', function() {
+    var jobid = currentRepeatJobId();
+    if (!jobid) {
+      $('#repeat-modal').foundation('reveal', 'close');
+      return;
+    }
+    var raw = $('#repeat-count').val();
+    var trimmed = (raw || '').toString().trim();
+    var count = null;
+    if (trimmed !== '') {
+      var n = parseInt(trimmed, 10);
+      if (!isFinite(n) || n < 1) {
+        fabmo.notify('error', 'Count must be a positive integer or blank');
+        return;
       }
+      count = n;
+    }
+    $('#repeat-modal').foundation('reveal', 'close');
+    fabmo.setJobRepeat(jobid, { repeat: true, count: count }, function(err) {
+      if (err) fabmo.notify('error', err);
     });
+  });
+
+  $('#repeat-off').on('click', function() {
+    var jobid = currentRepeatJobId();
+    if (!jobid) {
+      $('#repeat-modal').foundation('reveal', 'close');
+      return;
+    }
+    $('#repeat-modal').foundation('reveal', 'close');
+    fabmo.setJobRepeat(jobid, { repeat: false, count: null }, function(err) {
+      if (err) fabmo.notify('error', err);
+    });
+  });
+
+  $('#repeat-cancel').on('click', function() {
+    $('#repeat-modal').foundation('reveal', 'close');
   });
 }
 

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -423,7 +423,11 @@ define(function (require) {
         this._registerHandler(
             "setJobRepeat",
             function (data, callback) {
-                this.engine.setJobRepeat(data.id, data.repeat, callback);
+                var opts = { repeat: !!data.repeat };
+                if (Object.prototype.hasOwnProperty.call(data, "count")) {
+                    opts.count = data.count;
+                }
+                this.engine.setJobRepeat(data.id, opts, callback);
             }.bind(this)
         );
 

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -764,8 +764,21 @@
         this._call("resubmitJob", args, callback);
     };
 
-    FabMoDashboard.prototype.setJobRepeat = function (id, repeat, callback) {
-        this._call("setJobRepeat", { id: id, repeat: !!repeat }, callback);
+    // setJobRepeat(id, opts, cb)
+    //   opts: boolean (legacy) — sets repeat on/off, leaves count untouched
+    //   opts: { repeat: bool, count?: number|null } — count is total runs
+    //         remaining (incl current); null/blank/<1 means indefinite.
+    FabMoDashboard.prototype.setJobRepeat = function (id, opts, callback) {
+        var payload;
+        if (typeof opts === "boolean") {
+            payload = { id: id, repeat: opts };
+        } else {
+            payload = { id: id, repeat: !!(opts && opts.repeat) };
+            if (opts && Object.prototype.hasOwnProperty.call(opts, "count")) {
+                payload.count = opts.count;
+            }
+        }
+        this._call("setJobRepeat", payload, callback);
     };
 
     FabMoDashboard.prototype.ghostRunJob = function (id, zOffset, callback) {

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -377,8 +377,21 @@
         this._post("/job/" + id, {}, callback, callback);
     };
 
-    FabMoAPI.prototype.setJobRepeat = function (id, repeat, callback) {
-        this._post("/job/" + id + "/repeat", { repeat: !!repeat }, callback, callback);
+    // setJobRepeat(id, opts, cb)
+    //   opts: boolean (legacy) — sets repeat on/off, leaves count untouched
+    //   opts: { repeat: bool, count?: number|null } — count is total runs
+    //         remaining (incl current); null/blank/<1 means indefinite.
+    FabMoAPI.prototype.setJobRepeat = function (id, opts, callback) {
+        var body;
+        if (typeof opts === "boolean") {
+            body = { repeat: opts };
+        } else {
+            body = { repeat: !!(opts && opts.repeat) };
+            if (opts && Object.prototype.hasOwnProperty.call(opts, "count")) {
+                body.count = opts.count;
+            }
+        }
+        this._post("/job/" + id + "/repeat", body, callback, callback);
     };
 
     FabMoAPI.prototype.ghostRunJob = function (id, zOffset, callback) {

--- a/db.js
+++ b/db.js
@@ -44,6 +44,49 @@ function notifyChange() {
     }
 }
 
+// Wait for the driver's previous cycle context to be fully released
+// (driver.context === null, set when stat:4 resolves the cycle promise),
+// then clone the just-finished job and kick off the next run. Polls every
+// 25ms with a generous 10s ceiling; if the context is still held after
+// that, we abort the restart rather than crash the runtime — the next user
+// action will surface the underlying driver hang.
+function scheduleRepeatRestart(srcJob, nextCount) {
+    var MAX_WAIT_MS = 10000;
+    var POLL_MS = 25;
+    var deadline = Date.now() + MAX_WAIT_MS;
+
+    function poll() {
+        var machine = require("./machine").machine;
+        if (!machine) return;
+        var ready =
+            !machine.status.job &&
+            machine.status.state === "idle" &&
+            (!machine.driver || !machine.driver.context);
+        if (!ready) {
+            if (Date.now() < deadline) {
+                return setTimeout(poll, POLL_MS);
+            }
+            log.warn(
+                "Repeat auto-restart aborted: driver still busy after " +
+                    MAX_WAIT_MS +
+                    "ms (state=" +
+                    machine.status.state +
+                    ", hasContext=" +
+                    !!(machine.driver && machine.driver.context) +
+                    ")"
+            );
+            return;
+        }
+        srcJob.clone({ repeatCount: nextCount }, function (cloneErr) {
+            if (cloneErr) return log.error("Repeat clone failed: " + cloneErr);
+            machine._runNextJob(true, function (runErr) {
+                if (runErr) log.error("Repeat auto-restart failed: " + runErr);
+            });
+        });
+    }
+    setImmediate(poll);
+}
+
 /* Job object has all of the features described.
  *   file_id refers to objects in the File collection.  Each job has a file, which is the CNC data that is run for that job.
  *   states for jobs:
@@ -66,6 +109,14 @@ var Job = function (options) {
     this.state = "pending";
     this.order = options.order || null;
     this.repeat = !!options.repeat;
+    // repeatCount: total runs remaining (including the current one).
+    //   null = indefinite (operator-stopped)
+    //   N    = N total runs left; decremented on each clone, stops when < 2
+    // Ignored when repeat is false.
+    this.repeatCount =
+        options.repeatCount === undefined || options.repeatCount === null
+            ? null
+            : Math.max(0, Math.floor(options.repeatCount));
     // Ghost mode: a transient one-shot clone that runs the job with a Z lift
     // for a dry-run / preview pass. ghost_restore_move snapshots the user's
     // transforms.move so we can put it back when the ghost run ends.
@@ -91,14 +142,23 @@ Job.prototype._restoreGhostTransform = function (callback) {
 };
 
 // Clone a job.  Used for re-running files, usually.
-// The `repeat` flag is carried into the clone so a repeating job keeps repeating
-// across the clone-on-finish cycle.
-Job.prototype.clone = function (callback) {
+// The `repeat` flag (and remaining count) are carried into the clone so a
+// repeating job keeps repeating across the clone-on-finish cycle. The caller
+// may override repeatCount (used by the repeat-on-finish path to decrement).
+Job.prototype.clone = function (overrides, callback) {
+    if (typeof overrides === "function") {
+        callback = overrides;
+        overrides = {};
+    }
     var job = new Job({
         file_id: this.file_id,
         name: this.name,
         description: this.description,
         repeat: this.repeat,
+        repeatCount:
+            overrides && Object.prototype.hasOwnProperty.call(overrides, "repeatCount")
+                ? overrides.repeatCount
+                : this.repeatCount,
     });
     job.save(callback);
 };
@@ -133,22 +193,26 @@ Job.prototype.finish = function (callback) {
         that.save(function (err, saved) {
             if (callback) callback(err, saved);
             if (err || that.ghost || !that.repeat) return;
+            // Decide whether this finish triggers another run. Count semantics:
+            // repeatCount === null  → run forever
+            // repeatCount === N     → N total runs remain; this is one of them,
+            //                          so the next run only happens if N >= 2
+            //                          (the clone gets N-1).
+            var nextCount = null;
+            if (that.repeatCount !== null && that.repeatCount !== undefined) {
+                if (that.repeatCount < 2) return; // this was the final scheduled run
+                nextCount = that.repeatCount - 1;
+            }
             // Repeat mode: clone the just-finished job back onto the queue and
-            // auto-start. Deferred so the runtime can complete its idle
-            // transition before we kick off the next run. Skipped for ghost
-            // runs — those are intentionally one-shot.
-            setImmediate(function () {
-                that.clone(function (cloneErr) {
-                    if (cloneErr) {
-                        return log.error("Repeat clone failed: " + cloneErr);
-                    }
-                    var machine = require("./machine").machine;
-                    if (!machine) return;
-                    machine._runNextJob(true, function (runErr) {
-                        if (runErr) log.error("Repeat auto-restart failed: " + runErr);
-                    });
-                });
-            });
+            // auto-start once the previous run's driver cycle is actually
+            // closed. Previously this fired on setImmediate, which usually
+            // happened to land after stat:4 cleared the G2 cycle context —
+            // but under event-loop pressure (e.g. an in-flight queue-change
+            // notification triggered by the repeat-modal save) the next
+            // runStream could start before context=null, throwing "Cannot
+            // create a new cycle context. One already exists." Skipped for
+            // ghost runs — those are intentionally one-shot.
+            scheduleRepeatRestart(that, nextCount);
         });
     });
 };

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -520,12 +520,27 @@ var getJobGCode = function (req, res, next) {
 
 // eslint-disable-next-line no-unused-vars
 var setJobRepeat = function (req, res, next) {
-    var desired = req.body && typeof req.body.repeat !== "undefined" ? !!req.body.repeat : null;
+    var body = req.body || {};
+    var desired = typeof body.repeat !== "undefined" ? !!body.repeat : null;
+    // count: integer = total runs (incl current), null = indefinite, absent =
+    // don't touch existing value. Negative/zero/NaN coerces to null.
+    var countProvided = Object.prototype.hasOwnProperty.call(body, "count");
+    var rawCount = body.count;
+    var parsedCount = null;
+    if (countProvided && rawCount !== null && rawCount !== "") {
+        var n = parseInt(rawCount, 10);
+        parsedCount = isFinite(n) && n >= 1 ? n : null;
+    }
     db.Job.getById(req.params.id, function (err, job) {
         if (err || !job) {
             return res.json({ status: "error", message: err || "Job not found" });
         }
         job.repeat = desired === null ? !job.repeat : desired;
+        if (!job.repeat) {
+            job.repeatCount = null;
+        } else if (countProvided) {
+            job.repeatCount = parsedCount;
+        }
         job.save(function (saveErr, saved) {
             if (saveErr) {
                 return res.json({ status: "error", message: saveErr });
@@ -542,6 +557,7 @@ var setJobRepeat = function (req, res, next) {
                 String(machine.status.job._id) === String(saved._id)
             ) {
                 machine.status.job.repeat = saved.repeat;
+                machine.status.job.repeatCount = saved.repeatCount;
             }
             res.json({ status: "success", data: { job: saved } });
         });


### PR DESCRIPTION
The per-job repeat toggle has moved off the running-card play cluster and into the icon-row toolbar (between Preview and Ghost Run). Clicking it now opens a Foundation reveal-modal where the operator enters a total run count, or leaves the field blank to repeat until canceled. A small green badge on the icon shows the remaining count when one is set; the button is gray when off and green with no badge when set to "until canceled". The Turn Off button is hidden when repeat is already off, so the modal collapses to just Save / Cancel in the common case.

Server side: the Job model picks up `repeatCount` (null = indefinite, N = total runs remaining including the current one). Job.clone takes an override so the auto-restart path can decrement N → N-1 on each finish and stop cloning when only the final run remains. setJobRepeat accepts { repeat, count } and mirrors both onto machine.status.job so a mid-run change takes effect on the very next finish().

Also fixes a "Cannot create a new cycle context. One already exists" race that surfaced when the modal save's notifyChange perturbed event- loop timing during a looped run. The repeat clone+restart used to fire on setImmediate, which usually landed after stat:4 cleared the G2 cycle context — but under load it could start the next iteration's runStream while the previous context was still held. The auto-restart now waits for machine.status.job to clear, state to be "idle", and driver.context to be null before kicking the clone; if any of those don't settle within 10s, it aborts the restart instead of crashing the runtime.

Front-end click handlers re-resolve the target job at click time rather than at modal-open time — so reducing or turning off repeat across a mid-run iteration boundary mutates the running clone, not the already- finished originator.