### PR TITLE
Make G2 disconnect surface to user; silence heartbeat log noise

### DIFF
--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -362,6 +362,18 @@
         this.command("resume", args, callback);
     };
 
+    // Trigger an explicit, user-initiated reconnect to the G2 motion controller.
+    // Used by the "Reconnect" button on the G2-disconnected modal.
+    FabMoAPI.prototype.reconnect = function (callback) {
+        this._post("/reconnect", {}, callback, callback);
+    };
+
+    // Cancel an in-flight reconnect retry loop. Used by the "Cancel" button
+    // on the "Reconnecting — first attempt failed" modal.
+    FabMoAPI.prototype.cancelReconnect = function (callback) {
+        this._post("/reconnect/cancel", {}, callback, callback);
+    };
+
     // Jobs
     FabMoAPI.prototype.getJobQueue = function (callback) {
         this._get("/jobs/queue", callback, callback, "jobs");

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -777,6 +777,20 @@ engine.getVersion(function (err, version) {
                             var cancelFunction = function () {
                                 dashboard.engine.quit();
                             };
+                            var reconnectFunction = function () {
+                                dashboard.engine.reconnect(function (err) {
+                                    if (err) {
+                                        console.error("Reconnect request failed:", err);
+                                    }
+                                });
+                            };
+                            var cancelReconnectFunction = function () {
+                                dashboard.engine.cancelReconnect(function (err) {
+                                    if (err) {
+                                        console.error("Cancel reconnect request failed:", err);
+                                    }
+                                });
+                            };
 
                             // Check for presence of an "input" request in "name"
                             if (status.info["input"] && status.info.input["name"]) {
@@ -824,6 +838,12 @@ engine.getVersion(function (err, version) {
                                             case "quit":
                                                 modalOptions.ok = cancelFunction;
                                                 break;
+                                            case "reconnect":
+                                                modalOptions.ok = reconnectFunction;
+                                                break;
+                                            case "cancelReconnect":
+                                                modalOptions.ok = cancelReconnectFunction;
+                                                break;
                                             default:
                                                 modalOptions.ok = function () {
                                                     modalIsShown = false;
@@ -847,6 +867,12 @@ engine.getVersion(function (err, version) {
                                                 break;
                                             case "quit":
                                                 modalOptions.cancel = cancelFunction;
+                                                break;
+                                            case "reconnect":
+                                                modalOptions.cancel = reconnectFunction;
+                                                break;
+                                            case "cancelReconnect":
+                                                modalOptions.cancel = cancelReconnectFunction;
                                                 break;
                                             default:
                                                 modalOptions.cancel = function () {

--- a/g2.js
+++ b/g2.js
@@ -203,12 +203,21 @@ function G2() {
     // Reconnection state
     this._reconnecting = false;
     this._reconnectTimer = null;
+    // Counts failed attempts within the current reconnect() loop, reset at
+    // each loop start. Used to drive the "first attempt failed" UX in machine.js.
+    this._reconnectAttempts = 0;
 
     // Status poll state
     this._lastDataReceived = 0;
     this._statusPollTimer = null;
     this._statusPollTimeout = null;
     this._statusPollPending = false;
+    // Set when the heartbeat probe has been written but its response not yet seen.
+    // Used to suppress logging of the probe's SR response in onData.
+    this._silentProbePending = false;
+    // Set after _handleDisconnect runs so onSerialClose / _write / etc. can
+    // short-circuit cleanly and only one "disconnect" event is emitted.
+    this._disconnected = false;
 }
 
 util.inherits(G2, events.EventEmitter);
@@ -476,16 +485,16 @@ G2.prototype.onSerialError = function (data) {
     });
 };
 
-// When the serial link to G2 is closed, attempt in-process reconnection
-// instead of exiting the process. Falls back to process.exit(14) after
-// MAX_RECONNECT_TIME if reconnection fails.
+// When the serial link to G2 is closed, log diagnostics and notify listeners.
+// Recovery is user-initiated — call G2.reconnect() explicitly (e.g. from the
+// /reconnect route or the dashboard's persistent disconnect dialog).
 G2.prototype.onSerialClose = function () {
     this.connected = false;
-    
+
     // === ENHANCED DIAGNOSTIC LOGGING ===
     var disconnectTime = new Date().toISOString();
     var timeSinceLastData = this._lastDataReceived ? (Date.now() - this._lastDataReceived) : 'N/A';
-    
+
     log.error("╔════════════════════════════════════════════════════════════════");
     log.error("║ G2 SERIAL DISCONNECT EVENT");
     log.error("╠════════════════════════════════════════════════════════════════");
@@ -504,12 +513,12 @@ G2.prototype.onSerialClose = function () {
     log.error("║ Quit Pending:        " + this.quit_pending);
     log.error("║ Last G2 Status:      stat=" + (this.status.stat || 'unknown'));
     log.error("║ Heartbeat Pending:   " + this._heartbeatPending);
-    
+
     // Log current runtime if available
     if (typeof global.CUR_RUNTIME !== 'undefined') {
         log.error("║ Current Runtime:     " + global.CUR_RUNTIME);
     }
-    
+
     log.error("╚════════════════════════════════════════════════════════════════");
 
     // Save log for diagnostics
@@ -521,37 +530,94 @@ G2.prototype.onSerialClose = function () {
 
     // Intentional close (firmware update) — do nothing
     if (intendedClose) {
-        log.info("Serial close was intentional (firmware update) - not reconnecting");
+        log.info("Serial close was intentional (firmware update) - not handling as disconnect");
         return;
     }
 
-    // Already in a reconnection cycle — let the retry loop handle it
+    // Already mid-reconnect — let the retry loop handle the close
     if (this._reconnecting) {
-        log.warn("Already in reconnection cycle - ignoring duplicate close event");
+        log.warn("Serial close during reconnect — handled by retry loop");
         return;
     }
 
-    // Start reconnection
-    this.reconnect();
+    this._handleDisconnect("serial_close");
 };
 
-// Attempt to reconnect to G2 with exponential backoff.
+// Mark the G2 link as down, clean up internal state, and notify listeners
+// so the dashboard can prompt the user. Idempotent — repeated calls are no-ops.
+// Recovery (G2.reconnect) is NOT triggered automatically; it must be invoked
+// explicitly (user action via /reconnect, or engine startup retry).
+G2.prototype._handleDisconnect = function (reason) {
+    if (this._disconnected) {
+        return;
+    }
+    this._disconnected = true;
+    this.connected = false;
+    this.stopStatusPoll();
+
+    var payload = {
+        reason: reason,
+        timestamp: new Date().toISOString(),
+        timeSinceLastData: this._lastDataReceived
+            ? Date.now() - this._lastDataReceived
+            : null,
+        lastStat: (this.status && this.status.stat) || null,
+        inCycle: !!this.context,
+        serialPath: this._serialPath || null,
+    };
+
+    // Drop listeners on the (now-stale) port so ghost events don't fire
+    if (this._serialPort) {
+        try {
+            this._serialPort.removeAllListeners();
+        } catch (e) {
+            log.warn("Error removing serial listeners on disconnect: " + e);
+        }
+    }
+
+    // Wipe queues / buffers / flags so a future reconnect starts clean
+    this._resetInternalState();
+
+    log.error(
+        "G2 link lost (reason=" + reason + ") — awaiting user-initiated reconnect"
+    );
+    this.emit("disconnect", payload);
+};
+
+// User-initiated reconnect to G2 with exponential backoff.
+// Called explicitly — by the /reconnect route, the dashboard's disconnect
+// dialog, or from engine startup when the initial connection failed.
 // Reuses the existing G2 object in-place so all external references
 // (machine.driver, runtimes, config) remain valid.
 G2.prototype.reconnect = function () {
+    if (this._reconnecting) {
+        log.warn("G2 reconnect already in progress — ignoring duplicate request");
+        return;
+    }
     var that = this;
     this._reconnecting = true;
+    this._reconnectAttempts = 0;
     this.stopStatusPoll();
 
-    // Notify listeners (machine.js) that the connection was lost
-    this.emit("disconnect");
+    // Notify listeners (machine.js) so the dashboard can swap the disconnect
+    // modal for a "Reconnecting…" modal. /reconnect returns 200 immediately;
+    // without this, the user would see the dialog dismiss and have no signal
+    // that retries are still in flight.
+    this.emit("reconnecting", {
+        timestamp: new Date().toISOString(),
+        maxTime: MAX_RECONNECT_TIME,
+        serialPath: this._serialPath || null,
+    });
 
-    // Clean up old serial port listeners to avoid ghost events
+    // _handleDisconnect normally has already cleaned up, but reconnect may also
+    // be called from a clean state (engine startup) — make these idempotent.
     if (this._serialPort) {
-        this._serialPort.removeAllListeners();
+        try {
+            this._serialPort.removeAllListeners();
+        } catch (e) {
+            log.warn("Error removing serial listeners during reconnect: " + e);
+        }
     }
-
-    // Reset all internal state (queues, buffers, callbacks, flags)
     this._resetInternalState();
 
     var startTime = Date.now();
@@ -608,7 +674,14 @@ G2.prototype.reconnect = function () {
 
                 that.connected = true;
                 that._reconnecting = false;
+                that._disconnected = false;
                 that._seen_ready = true;
+
+                // Wire the global serial close/error handlers to the new port so
+                // a subsequent disconnect is detected (the retry loop only
+                // attached local close/error handlers for the open attempt).
+                that._serialPort.on("close", that.onSerialClose.bind(that));
+                that._serialPort.on("error", that.onSerialError.bind(that));
 
                 // Send kill commands to clear any stale G2 state, then notify success
                 that._write("\x04\n", function () {});
@@ -671,6 +744,15 @@ G2.prototype.reconnect = function () {
     }
 
     function scheduleNextRetry() {
+        // Bail out if the user cancelled while an attempt was in flight
+        if (!that._reconnecting) {
+            return;
+        }
+        that._reconnectAttempts += 1;
+        that.emit("reconnect-attempt-failed", {
+            attempt: that._reconnectAttempts,
+            nextDelayMs: delay,
+        });
         that._reconnectTimer = setTimeout(function () {
             that._reconnectTimer = null;
             attemptReconnect();
@@ -686,6 +768,35 @@ G2.prototype.reconnect = function () {
     }, RECONNECT_BASE_DELAY);
 };
 
+// User-initiated cancel of the reconnect retry loop. Clears the pending timer
+// and re-emits "disconnect" so the dashboard restores the disconnect modal
+// (with the Reconnect button) for the user to try again later.
+G2.prototype.cancelReconnect = function () {
+    if (!this._reconnecting) {
+        return false;
+    }
+    log.warn("User cancelled G2 reconnect retry loop");
+    if (this._reconnectTimer) {
+        clearTimeout(this._reconnectTimer);
+        this._reconnectTimer = null;
+    }
+    this._reconnecting = false;
+    // _disconnected remains true — we are still not connected. Re-emit so the
+    // dashboard updates its modal (idempotency in _handleDisconnect would
+    // otherwise swallow this).
+    this.emit("disconnect", {
+        reason: "user_cancelled",
+        timestamp: new Date().toISOString(),
+        timeSinceLastData: this._lastDataReceived
+            ? Date.now() - this._lastDataReceived
+            : null,
+        lastStat: (this.status && this.status.stat) || null,
+        inCycle: !!this.context,
+        serialPath: this._serialPath || null,
+    });
+    return true;
+};
+
 // Start periodic status poll to detect silent G2 failures.
 // Sends a status report request if no data has been received recently.
 // (Distinct from the blue LED "heartbeat" pulsing on the G2 card itself.)
@@ -693,7 +804,7 @@ G2.prototype.startStatusPoll = function () {
     this.stopStatusPoll();
     this._statusPollTimer = setInterval(
         function () {
-            if (!this.connected || this._reconnecting) {
+            if (!this.connected || this._reconnecting || this._disconnected) {
                 return;
             }
             // Use longer timeout during feedhold — G2 is alive but paused
@@ -703,16 +814,8 @@ G2.prototype.startStatusPoll = function () {
             if (Date.now() - this._lastDataReceived < STATUS_POLL_INTERVAL) {
                 return;
             }
-            // Send a status report request as a status poll probe.
-            // During feedhold, bypass command_queue: sendMore() blocks all sends while
-            // pause_flag is true, so a queued probe would never reach G2. G2 still
-            // services JSON queries on its control channel during hold and will respond.
             this._statusPollPending = true;
-            if (inHold) {
-                this._write(JSON.stringify({ sr: null }) + "\n", function () {});
-            } else {
-                this.command({ sr: null });
-            }
+            this._sendSilentProbe();
 
             // Set timeout for response
             this._statusPollTimeout = setTimeout(
@@ -726,6 +829,20 @@ G2.prototype.startStatusPoll = function () {
         }.bind(this),
         STATUS_POLL_INTERVAL
     );
+};
+
+// Write the heartbeat probe directly to the serial port, bypassing command_queue
+// AND the normal g2 log. The probe is identical in shape to a user-requested SR,
+// so we tag _silentProbePending so onData can suppress logging of the response.
+// _ignored_responses is incremented to balance flow control accounting (the
+// returned {"r":{"sr":...}} should not be counted as a completed gcode line).
+G2.prototype._sendSilentProbe = function () {
+    if (!this._serialPort || !this._serialPort.isOpen) {
+        return;
+    }
+    this._silentProbePending = true;
+    this._ignored_responses += 1;
+    this._serialPort.write(JSON.stringify({ sr: null }) + "\n", function () {});
 };
 
 // Stop the status poll timer and any pending response timeout
@@ -742,7 +859,10 @@ G2.prototype.stopStatusPoll = function () {
 };
 
 // Called when G2 fails to respond to a status poll within STATUS_POLL_TIMEOUT.
-// Triggers reconnection by closing the serial port (which fires onSerialClose).
+// Logs diagnostics, closes the port (which triggers onSerialClose ->
+// _handleDisconnect), and falls back to _handleDisconnect directly if the
+// close attempt itself fails. No automatic reconnect — the user is notified
+// via the "disconnect" event and must invoke G2.reconnect() explicitly.
 G2.prototype._onStatusPollTimeout = function () {
     var timeoutTime = new Date().toISOString();
     var timeSinceLastData = Date.now() - this._lastDataReceived;
@@ -759,22 +879,16 @@ G2.prototype._onStatusPollTimeout = function () {
     log.error("╚════════════════════════════════════════════════════════════════");
 
     this.stopStatusPoll();
-    // Try to close the port gracefully, which triggers onSerialClose -> reconnect
     try {
         this._serialPort.close(function (err) {
             if (err) {
                 log.warn("Error closing port after status poll timeout: " + err);
-                // Port may already be in a bad state — trigger reconnect directly
-                if (!this._reconnecting) {
-                    this.reconnect();
-                }
+                this._handleDisconnect("heartbeat_timeout");
             }
         }.bind(this));
     } catch (e) {
         log.warn("Exception closing port after status poll timeout: " + e);
-        if (!this._reconnecting) {
-            this.reconnect();
-        }
+        this._handleDisconnect("heartbeat_timeout");
     }
 };
 
@@ -782,10 +896,8 @@ G2.prototype._onStatusPollTimeout = function () {
 G2.prototype._write = function (s, callback) {
     if (!this.connected || !this._serialPort || !this._serialPort.isOpen) {
         log.error("Attempted write while disconnected: " + String(s).substring(0, 50));
-        // Trigger reconnection if not already in progress
-        if (!this._reconnecting) {
-            log.error("Write to disconnected port — initiating reconnection.");
-            this.reconnect();
+        if (!this._reconnecting && !this._disconnected) {
+            this._handleDisconnect("write_failed");
         }
         if (callback) {
             setImmediate(callback);
@@ -855,7 +967,17 @@ G2.prototype.onData = function (data) {
             try {
                 // Responses from G2 are in JSON format (always) so we parse them out, and handle the messages
                 var obj = JSON.parse(json_string);
-                log.g2("S", "in", json_string);
+                // Suppress logging the SR response that came back from a silent
+                // heartbeat probe — keeps the g2 log free of idle noise.
+                var isSilentProbeResponse =
+                    this._silentProbePending &&
+                    obj &&
+                    ((obj.r && obj.r.sr) || obj.sr);
+                if (isSilentProbeResponse) {
+                    this._silentProbePending = false;
+                } else {
+                    log.g2("S", "in", json_string);
+                }
                 this.onMessage(obj);
             } catch (e) {
                 this.handleExceptionReport(e);

--- a/machine.js
+++ b/machine.js
@@ -306,16 +306,92 @@ function Machine(control_path, callback) {
         }.bind(this)
     );
 
-    // Handle G2 serial disconnection — set machine to not_ready and wait for reconnection
+    // Handle G2 serial disconnection — set machine to not_ready and prompt the
+    // user to recover. Auto-reconnect was removed so disconnects aren't masked;
+    // the dashboard surfaces a persistent modal with a "Reconnect" button that
+    // POSTs to /reconnect (which calls G2.reconnect()).
     this.driver.on(
         "disconnect",
-        function () {
+        function (payload) {
             log.warn("G2 driver reported disconnect — machine entering not_ready state");
             this.status.state = "not_ready";
             this.info_id += 1;
+            var reason = (payload && payload.reason) || "unknown";
+            var detail =
+                "Reason: " + reason +
+                (payload && payload.timeSinceLastData != null
+                    ? "  •  Last data: " + payload.timeSinceLastData + " ms ago"
+                    : "") +
+                (payload && payload.lastStat != null
+                    ? "  •  Last G2 stat: " + payload.lastStat
+                    : "");
             this.status.info = {
                 id: this.info_id,
-                message: "Motion controller disconnected — attempting to reconnect...",
+                message:
+                    "Motion controller disconnected. Check the USB cable / power, then click Reconnect to recover.",
+                custom: {
+                    title: "G2 Disconnected",
+                    detail: detail,
+                    ok: { text: "Reconnect", func: "reconnect" },
+                    cancel: null,
+                },
+            };
+            this.emit("status", this.status);
+        }.bind(this)
+    );
+
+    // While the user-initiated retry loop is running, keep a modal up so the
+    // user knows recovery is in progress (the disconnect modal was dismissed
+    // by the Reconnect click before the connection actually came back).
+    this.driver.on(
+        "reconnecting",
+        function (payload) {
+            log.info("G2 driver entering reconnect retry loop — notifying dashboard");
+            this.info_id += 1;
+            var maxMin = payload && payload.maxTime
+                ? Math.round(payload.maxTime / 60000)
+                : 5;
+            this.status.info = {
+                id: this.info_id,
+                message:
+                    "Reconnecting to motion controller… If the cable was unplugged, plug it back in now. " +
+                    "Retrying for up to " + maxMin + " minutes.",
+                custom: {
+                    title: "Reconnecting…",
+                    noButton: true,
+                    ok: null,
+                    cancel: null,
+                },
+            };
+            this.emit("status", this.status);
+        }.bind(this)
+    );
+
+    // After the first retry attempt fails (~1s after Reconnect was clicked),
+    // swap the "Reconnecting…" modal for one that exposes a Cancel button.
+    // The user clicks Reconnect, sees a brief Reconnecting modal, and within
+    // a second knows whether to wait or cancel.
+    this.driver.on(
+        "reconnect-attempt-failed",
+        function (payload) {
+            var attempt = (payload && payload.attempt) || 1;
+            // Only swap on the first failure — subsequent failures keep the
+            // same modal up. (Updating info_id every retry would flicker.)
+            if (attempt !== 1) {
+                return;
+            }
+            log.info("First G2 reconnect attempt failed — offering Cancel");
+            this.info_id += 1;
+            this.status.info = {
+                id: this.info_id,
+                message:
+                    "First reconnect attempt failed. Plug the cable in (or check power) and we'll keep retrying. " +
+                    "Click Cancel to stop.",
+                custom: {
+                    title: "Reconnecting — first attempt failed",
+                    ok: null,
+                    cancel: { text: "Cancel", func: "cancelReconnect" },
+                },
             };
             this.emit("status", this.status);
         }.bind(this)

--- a/routes/reconnect.js
+++ b/routes/reconnect.js
@@ -1,0 +1,73 @@
+var machine = require("../machine").machine;
+var log = require("../log").logger("routes");
+
+/**
+ * @api {post} /reconnect Reconnect to G2
+ * @apiGroup State
+ * @apiDescription Trigger an explicit, user-initiated reconnection to the G2
+ * motion controller. Auto-reconnect on runtime disconnect has been removed;
+ * the dashboard's persistent disconnect dialog calls this when the user
+ * confirms recovery.
+ * @apiSuccess {String} status `success` if reconnection sequence started,
+ *                              `idle` if already connected
+ * @apiError {String} status `error`
+ * @apiError {Object} message Error message
+ */
+// eslint-disable-next-line no-unused-vars
+var reconnect = function (req, res, next) {
+    try {
+        var driver = machine && machine.driver;
+        if (!driver) {
+            return res.json({
+                status: "error",
+                message: "Driver not initialized",
+            });
+        }
+        if (driver.connected && !driver._disconnected) {
+            return res.json({
+                status: "idle",
+                message: "G2 already connected",
+            });
+        }
+        log.info("User-initiated G2 reconnect via /reconnect");
+        driver.reconnect();
+        res.json({ status: "success", data: null });
+    } catch (e) {
+        log.error("Error invoking driver.reconnect: " + e);
+        res.json({ status: "error", message: String(e) });
+    }
+};
+
+/**
+ * @api {post} /reconnect/cancel Cancel reconnect retry loop
+ * @apiGroup State
+ * @apiDescription Stop the user-initiated reconnect retry loop. The disconnect
+ * modal is restored so the user can choose whether to try again later.
+ * @apiSuccess {String} status `success` if a loop was running and was cancelled,
+ *                              `idle` if no retry loop was in progress
+ */
+// eslint-disable-next-line no-unused-vars
+var cancelReconnect = function (req, res, next) {
+    try {
+        var driver = machine && machine.driver;
+        if (!driver) {
+            return res.json({
+                status: "error",
+                message: "Driver not initialized",
+            });
+        }
+        var cancelled = driver.cancelReconnect();
+        res.json({
+            status: cancelled ? "success" : "idle",
+            data: null,
+        });
+    } catch (e) {
+        log.error("Error invoking driver.cancelReconnect: " + e);
+        res.json({ status: "error", message: String(e) });
+    }
+};
+
+module.exports = function (server) {
+    server.post("/reconnect", reconnect);
+    server.post("/reconnect/cancel", cancelReconnect);
+};


### PR DESCRIPTION
Runtime auto-reconnect was masking real disconnects and the 5s status-poll probe was clogging g2.log on idle. Replace the silent retry with a visible, user-controlled recovery flow.

- g2.js: heartbeat probe now writes via _sendSilentProbe (bypasses both command_queue and log.g2); the matching SR response is suppressed in onData via _silentProbePending. Idle g2.log no longer accumulates probe TX/RX every 5s.
- g2.js: drop auto-reconnect from onSerialClose, _onStatusPollTimeout, and _write-to-closed-port. New _handleDisconnect(reason) is idempotent and emits a "disconnect" event with diagnostic payload (reason, timeSinceLastData, lastStat, inCycle, serialPath). reconnect() is now strictly user-invoked, re-entry guarded, and re-wires onSerialClose to the new port on success so second disconnects are still detected. New emit("reconnecting") at retry loop entry and emit("reconnect-attempt-failed", {attempt, nextDelayMs}) on each retry. New cancelReconnect() clears the timer and re-emits disconnect.
- routes/reconnect.js: POST /reconnect and POST /reconnect/cancel.
- machine.js: disconnect handler now sets info.custom with a "Reconnect" button and a diagnostic detail line (no more misleading "attempting to reconnect..." message). New "reconnecting" listener shows a no-button "Reconnecting..." modal; "reconnect-attempt-failed" listener swaps to a modal with a Cancel button after the first attempt fails.
- dashboard: fabmoapi gains reconnect() and cancelReconnect(); main.js status-info modal switch handles new "reconnect" and "cancelReconnect" func values.

Recovery path is now: Disconnected modal -> click Reconnect -> Reconnecting modal -> (on first failure) modal with Cancel -> on success, restored to idle via _restoreAfterReconnect.