### PR TITLE
Dashboard: make FabMoAPI a singleton; harden manual-modal hide logic

### DIFF
--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -44,7 +44,18 @@
         return job;
     };
 
+    // Singleton: every `new FabMoAPI()` returns the same instance, so all
+    // dashboard modules (main.js, routers.js, apps) share one websocket
+    // connection. Previously each module created its own FabMoAPI which
+    // spawned a separate socket; after a page refresh the old sockets
+    // weren't getting torn down promptly (no disconnect events on the
+    // server until the socket.io ping timeout, ~45s), and the duplicate
+    // connections competed for status/ping messages, leaving the dashboard
+    // unable to see state updates ("stuck keypad" symptom).
+    var _instance = null;
     var FabMoAPI = function (base_url) {
+        if (_instance) return _instance;
+        _instance = this;
         this.events = {
             status: [],
             disconnect: [],

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -635,7 +635,15 @@ engine.getVersion(function (err, version) {
                     }
                 }
 
-                if (status.state !== "manual" && last_state_seen === "manual") {
+                // Hide modal whenever the server isn't reporting "manual".
+                // Previously this only fired on a transition (last_state_seen
+                // === "manual"), but if the websocket missed an early status
+                // update (common right after a page refresh — sometimes the
+                // first status arrives before last_state_seen is set, or the
+                // socket misses messages during reconnect), the transition
+                // condition would never be satisfied and the modal would
+                // stay stuck even though the server was idle.
+                if (status.state !== "manual" && $(".manual-drive-modal").is(":visible")) {
                     $(".modalDim").hide();
                     $(".manual-drive-modal").hide();
                     keyboard.setEnabled(false);
@@ -1495,8 +1503,11 @@ if (slider) {
 $(document).on("keydown", function (e) {
     // escape key press to quit the engine
     if (e.key === "Escape") {
-        // do this only if in manual mode
-        if (last_state_seen === "manual") {
+        // Trigger exit any time the modal is visible. Checking modal
+        // visibility avoids being blocked by a stale last_state_seen, which
+        // can happen if the dashboard missed early status updates after a
+        // page refresh.
+        if ($(".manual-drive-modal").is(":visible")) {
             console.warn("ESC key pressed - quitting manual mode.");
             startManualExit()
                 .then(() => {


### PR DESCRIPTION
Stuck-keypad bug: open keypad, refresh browser, click Exit -> keypad stays visible. Required a second refresh to clear, OR opening another browser tab. Manual control was effectively wedged.

Root cause: the dashboard was creating two FabMoAPI instances per page load (one in main.js, one in routers.js), so the browser opened two simultaneous websocket connections to /private. On page refresh, the OLD connections didn't get torn down promptly on the server (no socket disconnect events for ~45s while socket.io's ping timer ran out). With duplicate connections to both private and public namespaces, status/ping messages got split across sockets and the dashboard's main status pipeline stopped seeing state updates. The hide-modal logic in the status handler only fires on the last_state_seen=="manual" -> not-manual transition, so without status updates flowing, the modal never hides.

Fix 1 (root cause): FabMoAPI is now a singleton. `new FabMoAPI()` returns the existing instance instead of creating a new socket each time. Verified live: stuck-keypad symptom gone, Exit works on first click after refresh.

Fix 2 (defensive): the hide-modal condition now checks modal visibility instead of last_state_seen ("hide whenever the server isn't reporting manual mode and the modal is up"), so a single missed status update can't leave the modal stranded.

Fix 3 (defensive): Escape key uses modal visibility too.

Note: dashboard apps in iframes still each create their own FabMoAPI (separate JS contexts), so multiple sockets per refresh will still appear in the logs from iframe apps. The bug was that the MAIN dashboard's two FabMoAPI instances were splitting its own status pipeline; iframes don't have that problem.