### PR TITLE
Fix: catch synchronous arm() throws in route handlers

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -1974,12 +1974,20 @@ Machine.prototype.runNextJob = function (callback) {
                 return callback(err);
             }
             if (pendingJobs.length > 0) {
-                this.arm(
-                    {
-                        type: "nextJob",
-                    },
-                    config.machine.get("auth_timeout")
-                );
+                // arm() throws synchronously when state is busy (e.g. rapid
+                // double-fire from the queue UI). Catch it here so the error
+                // surfaces through the callback instead of escaping the db
+                // callback boundary as an uncaught exception.
+                try {
+                    this.arm(
+                        {
+                            type: "nextJob",
+                        },
+                        config.machine.get("auth_timeout")
+                    );
+                } catch (e) {
+                    return callback(e);
+                }
                 callback();
             } else {
                 callback(new Error("No pending jobs."));

--- a/routes/direct.js
+++ b/routes/direct.js
@@ -23,27 +23,35 @@ var code = function (req, res, next) {
             if (req.params.runtime !== undefined) {
                 var rt = req.params.runtime.toLowerCase().trim();
                 var debug = !!req.params.debug;
-                switch (rt) {
-                    case "opensbp":
-                    case "sbp":
-                        machine.sbp(req.params.cmd, { debug: debug });
-                        break;
+                try {
+                    switch (rt) {
+                        case "opensbp":
+                        case "sbp":
+                            machine.sbp(req.params.cmd, { debug: debug });
+                            break;
 
-                    case "g":
-                    case "nc":
-                    case "gcode":
-                        if (debug) {
-                            log.warn("debug flag ignored for gcode runtime");
-                        }
-                        machine.gcode(req.params.cmd);
-                        break;
+                        case "g":
+                        case "nc":
+                        case "gcode":
+                            if (debug) {
+                                log.warn("debug flag ignored for gcode runtime");
+                            }
+                            machine.gcode(req.params.cmd);
+                            break;
 
-                    default:
-                        answer = {
-                            status: "error",
-                            message: "Runtime '" + rt + "' is unknown.",
-                        };
-                        break;
+                        default:
+                            answer = {
+                                status: "error",
+                                message: "Runtime '" + rt + "' is unknown.",
+                            };
+                            break;
+                    }
+                } catch (e) {
+                    // machine.sbp/gcode -> executeRuntimeCode -> arm() throws
+                    // synchronously when state is busy. Surface as JSON error
+                    // instead of letting it escape as an uncaught exception.
+                    log.warn("/code: " + e.message);
+                    answer = { status: "error", message: e.message };
                 }
             } else {
                 answer = {

--- a/routes/macros.js
+++ b/routes/macros.js
@@ -1,4 +1,5 @@
 var macros = require("../macros");
+var log = require("../log").logger("api");
 
 // eslint-disable-next-line no-unused-vars
 var updateMacro = function (req, res, next) {
@@ -102,7 +103,19 @@ var runMacro = function (req, res, next) {
     var id = req.params.id;
     var macro = macros.get(id);
     if (macro) {
-        macros.run(id);
+        // macros.run -> machine.runFile -> arm() throws synchronously if the
+        // machine is busy (e.g. already running another macro from a rapid
+        // double-click). Without this guard the throw escapes the route
+        // handler and tears down the process.
+        try {
+            macros.run(id);
+        } catch (e) {
+            log.warn("runMacro: " + e.message);
+            return res.json({
+                status: "error",
+                message: e.message,
+            });
+        }
         res.json({
             status: "success",
             data: macros.list(),

--- a/routes/state.js
+++ b/routes/state.js
@@ -1,4 +1,5 @@
 var machine = require("../machine").machine;
+var log = require("../log").logger("api");
 
 /**
  * @api {get} /quit Quit
@@ -49,12 +50,13 @@ var pause = function (req, res, next) {
  */
 // eslint-disable-next-line no-unused-vars
 var resume = function (req, res, next) {
-    machine.resume();
-    var answer = {
-        status: "success",
-        data: null,
-    };
-    res.json(answer);
+    try {
+        machine.resume();
+    } catch (e) {
+        log.warn("resume: " + e.message);
+        return res.json({ status: "error", message: e.message });
+    }
+    res.json({ status: "success", data: null });
 };
 
 module.exports = function (server) {


### PR DESCRIPTION
Rapid double-clicking a macro play button could crash the entire fabmo process. Trace:

  UNCAUGHT EXCEPTION
  Error: Cannot arm the machine from the running state.
      at Object.run (macros.js:385)
      at runMacro (routes/macros.js:105)

Machine.arm() throws synchronously when called against a busy state (running, paused, probing, etc.). Several route handlers invoke arm- adjacent methods (runFile, resume, sbp, gcode, runNextJob) without catching that throw, so the exception escapes the request and tears down the engine. WebSocket handlers were already wrapped in try/catch and were fine.

Patches:

- routes/macros.js  runMacro: wrap macros.run() (the macro play
  trigger). Returns {status: "error", message} instead of crashing.

- routes/state.js   resume: wrap machine.resume(). Same.

- routes/direct.js  /code: wrap the runtime switch covering machine.sbp() and machine.gcode().

- machine.js  Machine.runNextJob: arm() runs inside the async db.Job.getPending callback, so an outer try/catch in the route can't see it. Wrap arm() inside the callback and pass the error to the user callback so routes/jobs.js gets it through its existing err-first path instead of via uncaught exception.

Verified live by hammering each endpoint while the machine was busy (probing). Five rapid /macros/2/run, /resume, /code, /jobs/queue/run hits each returned a clean JSON error; fabmo stayed up.