### PR TITLE
Manual profile change: defer next() until response is sent

### DIFF
--- a/routes/config.js
+++ b/routes/config.js
@@ -553,6 +553,7 @@ function applyManualProfileChange(profileName, res, next) {
             });
             log.info("fabmo-def updated; handing off to engine profile-change pipeline");
             res.end();
+            next();
 
             // Step 3: actually trigger the profile change. engine_config
             // will call profiles.apply and then process.exit(1) - we
@@ -573,8 +574,6 @@ function applyManualProfileChange(profileName, res, next) {
             });
         });
     });
-
-    next();
 }
 
 // Get backup restore status


### PR DESCRIPTION
The synchronous next() at the end of applyManualProfileChange let restify finalize the response before the async setProfileName → clearDefault → res.json chain ran. When the callback later called res.json, headers were already sent, the uncaught exception killed the engine, and config.engine.set("profile", ...) never executed — so the profile change never actually applied.

Move next() inside the clearDefault callback after res.end().