### PR TITLE
Configuration: rework My Default Settings as My Custom Settings

### DIFF
--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -2122,38 +2122,46 @@
 
       </section>
 
-<!-- MY DEFAULT SETTINGS SECTION -->
+<!-- MY CUSTOM SETTINGS SECTION -->
       <section>
         <div class="row">
           <fieldset>
-            <legend>My Default Settings</legend>
+            <legend>My Custom Settings</legend>
             <div class="large-12 columns">
               <p style="margin-bottom: 10px;">
-                Save the current configuration as your personal default. If a settings file is ever damaged
-                and the most recent backup can't be used, the machine will fall back to your saved default
-                instead of the factory profile.
+                Save the current configuration as a custom profile you can restore later. The
+                most recently saved profile is marked as your Preferred Settings &mdash; if a
+                settings file is ever damaged and the most recent backup can't be used, the
+                machine falls back to the Preferred profile instead of the factory profile.
               </p>
             </div>
-            <div class="large-8 columns">
-              <div class="row collapse">
-                <a id="btn-save-default" class="button radius small" style="background-color:rgb(83, 133, 224)">Save current settings as my default</a>
-                <a id="btn-reset-default" class="button radius small" style="background-color:rgb(41, 175, 41); margin-left:8px;">Reset to my default settings</a>
+            <div class="large-12 columns" style="margin-bottom: 10px;">
+              <div class="row collapse" style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                <a id="btn-save-default" class="button radius small" style="background-color:rgb(83, 133, 224); margin:0;">Save current settings as custom profile</a>
+                <a id="btn-reset-default" class="button radius small" style="background-color:rgb(41, 175, 41); margin:0;">Restore machine settings to custom profile</a>
               </div>
             </div>
-            <div class="large-4 columns">
-              <div class="row collapse" style="line-height: 32px;">
-                <span>Current default: </span><span id="current-default-name" style="font-weight: bold;">none</span>
+            <div class="large-12 columns">
+              <div class="row collapse" style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                <label style="margin:0; line-height:32px;">Snapshot:</label>
+                <select id="custom-snapshot-select" style="width:200px; margin:0;"></select>
+                <a id="btn-set-preferred" class="button radius small secondary" style="margin:0;">Set as Preferred</a>
+                <a id="btn-download-snapshot" class="button radius small secondary" title="Download selected custom profile" style="margin:0;">Download</a>
+                <a id="btn-upload-snapshot" class="button radius small secondary" title="Upload a custom profile from a .fmsnap.zip" style="margin:0;">Upload</a>
+                <input type="file" id="upload-snapshot-file" class="hidden" accept=".zip,application/zip">
+                <span style="margin-left:12px; line-height:32px;">Preferred Settings: <span id="current-default-name" style="font-weight: bold;">none</span></span>
+                <a id="btn-delete-snapshot" class="button radius small alert" title="Delete selected snapshot" style="display:none; margin:0; padding:0 10px;"><i class="fa fa-trash"></i></a>
               </div>
             </div>
           </fieldset>
         </div>
       </section>
 
-<!-- Save-as-default dialog. Inline modal because the app runs in a
+<!-- Save-as-custom-profile dialog. Inline modal because the app runs in a
      sandboxed iframe that blocks window.prompt(). -->
       <div id="save-default-dialog" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); z-index:9999;">
         <div style="background:white; max-width:420px; margin:80px auto; padding:20px; border-radius:6px;">
-          <h4 style="margin-top:0;">Save current settings as my default</h4>
+          <h4 style="margin-top:0;">Save current settings as custom profile</h4>
           <div style="margin-bottom:10px;">
             <label>Name <span style="color:#999;font-weight:normal;">(1-25 chars: letters, digits, _ or -)</span></label>
             <input type="text" id="save-default-name" maxlength="25" autocomplete="off">

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -825,24 +825,47 @@ function ensureProfileDisplayCorrect() {
     });
 }
 
-// "Save current settings as my default": create a snapshot from the
-// current /opt/fabmo/config + macros, then mark it as the user-default
-// fallback. This is the user-friendly entry into the snapshot system -
-// it does not modify any shipped profiles.
+// "My Custom Settings": create a snapshot from the current /opt/fabmo/config +
+// macros, then mark it as the Preferred fallback the recovery chain will reach
+// for. This is the user-friendly entry into the snapshot system — it does not
+// modify any shipped profiles.
+//
+// Refreshes both the snapshot dropdown and the Preferred Settings label.
+// Filters to kind="user" so auto recovery snapshots (which rotate on their
+// own and aren't user-meaningful) don't clutter the picker.
 function refreshDefaultSnapshotName() {
     fetch('/snapshots')
         .then(function (r) { return r.json(); })
         .then(function (resp) {
-            if (resp && resp.status === 'success' && resp.data && resp.data.snapshots) {
-                var def = null;
-                for (var i = 0; i < resp.data.snapshots.length; i++) {
-                    if (resp.data.snapshots[i].is_user_default) {
-                        def = resp.data.snapshots[i];
-                        break;
-                    }
-                }
-                $('#current-default-name').text(def ? def.name : 'none');
+            var all = (resp && resp.status === 'success' && resp.data) ? (resp.data.snapshots || []) : [];
+            var userSnaps = all.filter(function (s) { return (s.kind || 'user') === 'user'; });
+            var preferred = null;
+            for (var i = 0; i < userSnaps.length; i++) {
+                if (userSnaps[i].is_user_default) { preferred = userSnaps[i]; break; }
             }
+
+            var $sel = $('#custom-snapshot-select');
+            var prev = $sel.val();
+            $sel.empty();
+            if (userSnaps.length === 0) {
+                $sel.append('<option value="">(no custom profiles yet)</option>');
+            } else {
+                for (var j = 0; j < userSnaps.length; j++) {
+                    var s = userSnaps[j];
+                    var label = s.name + (s.is_user_default ? '  (Preferred)' : '');
+                    $sel.append($('<option></option>').val(s.name).text(label));
+                }
+            }
+            // Preserve the user's prior selection if it still exists; otherwise
+            // fall back to the Preferred snapshot so the action buttons act on
+            // the most useful default.
+            if (prev && userSnaps.some(function (s) { return s.name === prev; })) {
+                $sel.val(prev);
+            } else if (preferred) {
+                $sel.val(preferred.name);
+            }
+
+            $('#current-default-name').text(preferred ? preferred.name : 'none');
         })
         .catch(function () { /* leave display alone on transient errors */ });
 }
@@ -895,66 +918,166 @@ $('#save-default-confirm').click(function () {
             var msg = resp && resp.message ? resp.message : 'could not mark as default';
             throw new Error('Snapshot saved but not marked as default: ' + msg);
         }
-        fabmo.notify('success', 'Saved current settings as your default: ' + name);
+        fabmo.notify('success', 'Saved as custom profile: ' + name);
         refreshDefaultSnapshotName();
     })
     .catch(function (err) {
-        fabmo.notify('error', err.message || 'Failed to save default.');
+        fabmo.notify('error', err.message || 'Failed to save custom profile.');
     });
 });
 
-// Reset to whatever snapshot is currently marked as the user-default.
-// Uses fabmo.showModal (no input fields needed) since the sandbox blocks
-// window.confirm() the same way it blocks prompt().
+// Restore from whatever snapshot is currently picked in the dropdown.
+// fabmo.showModal is used here (instead of window.confirm) because the app
+// runs in a sandboxed iframe that blocks confirm/prompt.
 $('#btn-reset-default').click(function () {
-    fetch('/snapshots')
+    var name = $('#custom-snapshot-select').val();
+    if (!name) {
+        fabmo.notify('warning', 'No custom profile selected.');
+        return;
+    }
+    fabmo.showModal({
+        title: 'Restore from custom profile?',
+        message: 'This will replace your current configuration and macros with "' + name + '". The tool will restart. A snapshot of your current settings is saved automatically first, so you can recover if needed.',
+        okText: 'Restore',
+        cancelText: 'Cancel',
+        ok: function () {
+            fabmo.notify('info', 'Restoring "' + name + '"...');
+            fetch('/snapshots/' + encodeURIComponent(name) + '/restore', {
+                method: 'POST'
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    if (!resp || resp.status !== 'success') {
+                        var msg = resp && resp.message ? resp.message : 'unknown error';
+                        fabmo.notify('error', 'Restore failed: ' + msg);
+                    }
+                    // On success the engine restarts; the page reloads on its own.
+                })
+                .catch(function (err) {
+                    fabmo.notify('error', 'Restore failed: ' + err.message);
+                });
+        },
+        cancel: function () {}
+    });
+});
+
+// Mark the dropdown's selected snapshot as the Preferred fallback. Refresh
+// the UI so the "(Preferred)" tag and label move to the new winner.
+$('#btn-set-preferred').click(function () {
+    var name = $('#custom-snapshot-select').val();
+    if (!name) {
+        fabmo.notify('warning', 'No custom profile selected.');
+        return;
+    }
+    fetch('/snapshots/' + encodeURIComponent(name) + '/set-default', {
+        method: 'POST'
+    })
         .then(function (r) { return r.json(); })
         .then(function (resp) {
-            var def = null;
-            if (resp && resp.status === 'success' && resp.data && resp.data.snapshots) {
-                for (var i = 0; i < resp.data.snapshots.length; i++) {
-                    if (resp.data.snapshots[i].is_user_default) {
-                        def = resp.data.snapshots[i];
-                        break;
-                    }
-                }
+            if (!resp || resp.status !== 'success') {
+                var msg = resp && resp.message ? resp.message : 'unknown error';
+                throw new Error(msg);
             }
-            if (!def) {
-                fabmo.notify('warning', 'No default is set yet. Use "Save current settings as my default" first.');
-                return;
-            }
-            fabmo.showModal({
-                title: 'Reset to my default settings?',
-                message: 'This will replace your current configuration and macros with your saved default "' + def.name + '". The tool will restart. A snapshot of your current settings is saved automatically first, so you can recover if needed.',
-                okText: 'Reset',
-                cancelText: 'Cancel',
-                ok: function () {
-                    fabmo.notify('info', 'Restoring "' + def.name + '"...');
-                    fetch('/snapshots/' + encodeURIComponent(def.name) + '/restore', {
-                        method: 'POST'
-                    })
-                        .then(function (r) { return r.json(); })
-                        .then(function (resp2) {
-                            if (!resp2 || resp2.status !== 'success') {
-                                var msg = resp2 && resp2.message ? resp2.message : 'unknown error';
-                                fabmo.notify('error', 'Reset failed: ' + msg);
-                            }
-                            // On success the engine restarts; the page will
-                            // reload on its own once it comes back up.
-                        })
-                        .catch(function (err) {
-                            fabmo.notify('error', 'Reset failed: ' + err.message);
-                        });
-                },
-                cancel: function () {}
-            });
+            fabmo.notify('success', 'Preferred Settings: ' + name);
+            refreshDefaultSnapshotName();
         })
         .catch(function (err) {
-            fabmo.notify('error', 'Could not check for default: ' + err.message);
+            fabmo.notify('error', 'Could not set Preferred: ' + err.message);
         });
 });
 
-// Show current default on load.
+// Delete the dropdown's selected snapshot. Confirmation modal because the
+// action is destructive and unrecoverable. Live machine settings are not
+// touched — only the saved profile is removed.
+$('#btn-delete-snapshot').click(function () {
+    var name = $('#custom-snapshot-select').val();
+    if (!name) {
+        fabmo.notify('warning', 'No custom profile selected.');
+        return;
+    }
+    fabmo.showModal({
+        title: 'Delete custom profile?',
+        message: 'This will permanently delete the custom profile "' + name + '". Your current machine settings are not affected.',
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        ok: function () {
+            fetch('/snapshots/' + encodeURIComponent(name), {
+                method: 'DELETE'
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    if (!resp || resp.status !== 'success') {
+                        var msg = resp && resp.message ? resp.message : 'unknown error';
+                        throw new Error(msg);
+                    }
+                    fabmo.notify('success', 'Deleted: ' + name);
+                    refreshDefaultSnapshotName();
+                })
+                .catch(function (err) {
+                    fabmo.notify('error', 'Delete failed: ' + err.message);
+                });
+        },
+        cancel: function () {}
+    });
+});
+
+// Download the dropdown-selected snapshot as a `.fmsnap.zip`. The browser
+// drives the download via a temporary anchor — server sets
+// Content-Disposition so the filename is `<name>.fmsnap.zip`.
+$('#btn-download-snapshot').click(function () {
+    var name = $('#custom-snapshot-select').val();
+    if (!name) {
+        fabmo.notify('warning', 'No custom profile selected.');
+        return;
+    }
+    var url = '/snapshots/' + encodeURIComponent(name) + '/download';
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = name + '.fmsnap.zip';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+});
+
+// Upload a previously-downloaded snapshot zip. Trigger flow mirrors the
+// macros restore: button -> hidden file input -> change -> multipart POST.
+$('#btn-upload-snapshot').click(function () {
+    $('#upload-snapshot-file').trigger('click');
+});
+
+$('#upload-snapshot-file').change(function () {
+    var files = $(this).prop('files');
+    if (!files || files.length !== 1) return;
+    var file = files[0];
+    fabmo.notify('info', 'Uploading custom profile...');
+    var formData = new FormData();
+    formData.append('file', file);
+
+    $.ajax({
+        url: '/snapshots/upload',
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        timeout: 120000
+    }).done(function (resp) {
+        if (resp && resp.status === 'success') {
+            var importedName = (resp.data && resp.data.name) || file.name;
+            fabmo.notify('success', 'Imported custom profile: ' + importedName);
+            refreshDefaultSnapshotName();
+        } else {
+            fabmo.notify('error', 'Upload failed: ' + ((resp && resp.message) || 'unknown'));
+        }
+    }).fail(function (xhr) {
+        var msg = 'unknown error';
+        try { msg = (JSON.parse(xhr.responseText) || {}).message || msg; } catch (e) {}
+        fabmo.notify('error', 'Upload failed: ' + msg);
+    }).always(function () {
+        $('#upload-snapshot-file').val('');
+    });
+});
+
+// Populate the dropdown and Preferred label on load.
 refreshDefaultSnapshotName();
 
 // ---------- Spindle Setup ----------

--- a/routes/config.js
+++ b/routes/config.js
@@ -879,6 +879,81 @@ var post_clear_default_snapshot = function (req, res, next) {
     });
 };
 
+// Stream a snapshot directory back as a zip file. Same archiver pattern as
+// backup_macros; output filename is `<name>.fmsnap.zip` so the import side
+// can recognize it on extension alone.
+var download_snapshot = function (req, res, next) {
+    var name = req.params && req.params.name;
+    var dir = snapshots.snapshotPath(name);
+    if (!fs.existsSync(dir)) {
+        res.send(404, { status: "error", message: "Snapshot not found: " + name });
+        return next();
+    }
+    var safeName = String(name).replace(/[^a-zA-Z0-9_-]/g, "_");
+    var fileName = safeName + ".fmsnap.zip";
+
+    res.setHeader("Content-Disposition", 'attachment; filename="' + fileName + '"');
+    res.setHeader("Content-Type", "application/zip");
+
+    var archive = archiver("zip", { zlib: { level: 9 } });
+    archive.on("error", function (err) {
+        log.error("snapshot download zip failed: " + err.message);
+        try { res.json({ status: "error", message: err.message }); } catch (e) {}
+        next();
+    });
+    archive.pipe(res);
+    archive.directory(dir, false);
+    archive.finalize();
+};
+
+// Accept an uploaded snapshot zip and register it as a user snapshot. Uses
+// the same temp-dir scavenge pattern as handleMacrosRestore — bodyParser
+// drops the file in tempDir and we pull the most recent one out.
+function handleSnapshotUpload(req, res, next) {
+    log.info("Snapshot upload endpoint hit");
+
+    var recentFiles = findRecentlyModifiedFiles(tempDir);
+    var zipCandidates = recentFiles.filter(function (f) {
+        return f.size > 0 && isZipFile(f.path) && f.name.indexOf("upload_") === 0;
+    });
+    if (zipCandidates.length === 0) {
+        res.send(400, { status: "error", message: "No valid ZIP file found in upload" });
+        return next();
+    }
+    var zipFile = zipCandidates[0];
+
+    // Extract to a per-request temp dir so concurrent uploads don't collide.
+    // Plain Node `fs` here (not fs-extra) — use recursive mkdir/rm rather
+    // than fs.ensureDir/fs.remove.
+    var extractDir = path.join(tempDir, "fabmo_snap_extract_" + Date.now() + "_" + process.pid);
+    var cleanup = function () {
+        fs.rm(extractDir, { recursive: true, force: true }, function () {});
+    };
+    fs.mkdir(extractDir, { recursive: true }, function (eErr) {
+        if (eErr) {
+            res.send(500, { status: "error", message: "Could not prep extract dir: " + eErr.message });
+            return next();
+        }
+        extract(zipFile.path, { dir: extractDir })
+            .then(function () {
+                snapshots.importFromDir(extractDir, function (impErr, finalName) {
+                    cleanup();
+                    if (impErr) {
+                        res.send(400, { status: "error", message: impErr.message });
+                        return next();
+                    }
+                    res.send(200, { status: "success", data: { name: finalName } });
+                    return next();
+                });
+            })
+            .catch(function (xErr) {
+                cleanup();
+                res.send(400, { status: "error", message: "ZIP extract failed: " + xErr.message });
+                return next();
+            });
+    });
+}
+
 module.exports = function (server) {
     server.post("/macros/restore", handleMacrosRestore);
     server.get("/macros/backup", backup_macros);
@@ -904,6 +979,10 @@ module.exports = function (server) {
     server.get("/snapshots", get_snapshots);
     server.post("/snapshots", post_snapshot);
     server.post("/snapshots/clear-default", post_clear_default_snapshot);
+    // Register literal-path routes (upload) before :name-parameterized ones
+    // so "upload" isn't mistaken for a snapshot name.
+    server.post("/snapshots/upload", handleSnapshotUpload);
+    server.get("/snapshots/:name/download", download_snapshot);
     server.post("/snapshots/:name/restore", post_snapshot_restore);
     server.post("/snapshots/:name/set-default", post_set_default_snapshot);
     server.del("/snapshots/:name", delete_snapshot);

--- a/snapshots.js
+++ b/snapshots.js
@@ -157,6 +157,75 @@ function create(name, description, callback) {
     _create(name, { kind: "user", description: description || "" }, callback);
 }
 
+// Public: register an extracted snapshot directory (typically the contents
+// of an uploaded `.fmsnap.zip`) under SNAPSHOT_DIR as a user snapshot.
+//
+// The source directory must look like a snapshot root: a snapshot_info.json
+// at the top with at least the `name` field. Name is sanitized against
+// USER_NAME_RE, reserved-prefix collisions are avoided, and if a snapshot
+// with the same name already exists a `_N` suffix is appended so the
+// existing one isn't clobbered. Kind is forced to "user" on import — auto
+// kind is reserved for the engine's own rotation.
+function importFromDir(srcDir, callback) {
+    if (typeof callback !== "function") {
+        callback = function () {};
+    }
+    if (!isIdle()) {
+        return callback(new Error("Machine must be idle to import a snapshot"));
+    }
+    var infoPath = path.join(srcDir, "snapshot_info.json");
+    if (!fs.existsSync(infoPath)) {
+        return callback(new Error("Not a valid snapshot zip: snapshot_info.json missing"));
+    }
+    var info;
+    try {
+        info = JSON.parse(fs.readFileSync(infoPath, "utf8"));
+    } catch (e) {
+        return callback(new Error("Snapshot info is corrupt: " + e.message));
+    }
+
+    var rawName = (info.name || "imported").toString();
+    var sanitized = rawName.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 25) || "imported";
+    if (isReservedName(sanitized)) {
+        sanitized = ("imported_" + sanitized).slice(0, 25);
+    }
+
+    // Resolve collisions by appending _N. Keep the existing snapshot
+    // untouched so the user can compare if they imported deliberately.
+    var finalName = sanitized;
+    if (fs.existsSync(snapshotPath(finalName))) {
+        var base = sanitized;
+        for (var n = 1; n <= 99; n++) {
+            var attempt = base.slice(0, 25 - (("_" + n).length)) + "_" + n;
+            if (!fs.existsSync(snapshotPath(attempt))) {
+                finalName = attempt;
+                break;
+            }
+            if (n === 99) {
+                return callback(new Error("Too many existing snapshots named '" + base + "*'"));
+            }
+        }
+    }
+
+    var dest = snapshotPath(finalName);
+    fs.copy(srcDir, dest, function (cpErr) {
+        if (cpErr) {
+            return callback(cpErr);
+        }
+        info.name = finalName;
+        info.kind = "user";
+        info.imported_at = new Date().toISOString();
+        fs.writeFile(path.join(dest, "snapshot_info.json"), JSON.stringify(info, null, 2), function (wErr) {
+            if (wErr) {
+                fs.remove(dest, function () {});
+                return callback(wErr);
+            }
+            log.info("imported snapshot as " + finalName);
+            callback(null, finalName);
+        });
+    });
+}
+
 // Public: create an automatic snapshot of the given kind, prune older ones
 // of the same kind. Bypasses idle and name-collision checks since callers
 // are the engine itself, not user actions.
@@ -637,6 +706,7 @@ function recoverFromMirror(name, callback) {
 module.exports = {
     create: create,
     createAuto: createAuto,
+    importFromDir: importFromDir,
     list: list,
     restore: restore,
     remove: remove,


### PR DESCRIPTION
The old "My Default Settings" panel collided with the many other uses of the word "default" in FabMo — profile defaults, factory defaults, axis defaults — and was a frequent source of confusion. Reframes the panel around two clearer concepts:

- "Custom Profile" is what gets saved/restored
- "Preferred Settings" is the one custom profile marked as the recovery fallback (replaces "Current Default")

Restore is no longer hardwired to the Preferred profile. The panel now shows a dropdown of user-created snapshots and the action buttons operate on whichever one is selected — letting the user A/B between profiles instead of treating them as one-way save points. Auto recovery snapshots are filtered out of the dropdown so they don't clutter the picker.

New actions:
- Set as Preferred — marks the dropdown selection as the fallback the recovery chain reaches for after the backup mirror.
- Download — streams the selected snapshot as <name>.fmsnap.zip (config + macros, same archiver pattern as backup_macros).
- Upload — accepts a .fmsnap.zip and registers it as a new user snapshot. Server-side de-collides the imported name with _N suffixes so existing snapshots are never clobbered, and forces kind=user so imports show in the dropdown.
- Delete handler is wired but the button is hidden for now (one CSS rule away from being live).

Server additions:
- snapshots.importFromDir(srcDir, cb) — validates a directory looks like a snapshot root, sanitizes the name, copies in, stamps imported_at.
- GET /snapshots/:name/download — zip stream.
- POST /snapshots/upload — extracts uploaded zip, hands off to importFromDir. Uses Node-native fs.mkdir/rm (routes/config.js imports plain fs, not fs-extra).

Routes registered with the literal /snapshots/upload path ahead of the :name-parameterized routes so "upload" isn't matched as a snapshot name.