### PR TITLE
Dashboard lib: register pendant_file_select event listener bucket

### DIFF
--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -137,6 +137,7 @@
             upload_progress: [],
             data_send: [],
             data_request: [],
+            pendant_file_select: [],
         };
     };
 


### PR DESCRIPTION
FabMoDashboard._on() reads this._event_listeners[name] without lazy initialization, so subscribing to an event not present in _init's map throws "Cannot read properties of undefined (reading 'push')". job_manager.fma calls fabmo.on('pendant_file_select', ...) and was crashing on load because that key wasn't in the listener map.

Adds pendant_file_select alongside the other registered events.