### PR TITLE
Fix resume-from-line for SBP jobs

### DIFF
--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -714,7 +714,10 @@ function bindMenuEvents() {
           // Get safeZ from config
           fabmo.getConfig(function(err, config) {
             var safeZ = (config && config.opensbp) ? config.opensbp.safeZpullUp : 0;
-            var inLine = job.final_line;
+            // Step back one line: the recorded final_line is where the machine
+            // was interrupted (potentially mid-move), so restart one line
+            // earlier to re-run the interrupted line in full.
+            var inLine = Math.max(1, job.final_line - 1);
             var jobName = job.name || '';
             var isSBP = /\.(sbp|sbc)$/i.test(jobName);
             var code, fileName, ext;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -414,7 +414,7 @@ SBPRuntime.prototype.runStream = function (text_stream) {
                     var lines = this.program.length;
                     if (this.machine) {
                         if (this.file_stack.length === 0) {
-                            this.machine.status.nb_lines = lines - 1;
+                            this.machine.status.nb_lines = lines;
                         }
                     }
 
@@ -1379,9 +1379,20 @@ SBPRuntime.prototype._end = function (error) {
         this.pending_error = error;
     }
 
-    // Capture final line info on the job before cleanup clears it
+    // Capture final line info on the job before cleanup clears it.
+    // Prefer G2's reported line (N-word value, which emit_gcode sets to the
+    // top-level SBP pc + 20) — the SBP runtime's pc races ahead of G2 because
+    // GCode is queued, so pc+1 can land past the program end while G2 is still
+    // executing an earlier statement. Convert pc (0-based) to 1-based source
+    // line. Fall back to pc+1 if G2 hasn't reported.
     if (this.machine && this.machine.status.job) {
-        this.machine.status.job.final_line = this.pc + 1;
+        var g2line = this.machine.status.line;
+        var lineFromG2 = g2line ? g2line - 20 + 1 : null;
+        if (lineFromG2 && lineFromG2 >= 1) {
+            this.machine.status.job.final_line = lineFromG2;
+        } else {
+            this.machine.status.job.final_line = this.pc + 1;
+        }
         this.machine.status.job.nb_lines = this.machine.status.nb_lines;
     }
 


### PR DESCRIPTION
The SBP runtime's program counter races ahead of G2 because emitted GCode is queued, so `pc+1` at _end() time could land past the program end while G2 was still executing an earlier statement (e.g., final_line recorded as 6 for a 4-line file stopped during line 2). Record from G2's N-word value instead — emit_gcode already sets N = top-level SBP pc + 20, mirroring how the GCode runtime recovers its line.

Also fix nb_lines off-by-one in runStream (was program.length - 1), and have restart-from-line step back one line so the interrupted move gets re-run in full.