### PR TITLE
SBP selection extract: restore sticky Z and handle 1D-first moves

### DIFF
--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -485,8 +485,11 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
     }
   }
 
-  // Scan backward from in-point to find tool setup commands
+  // Scan backward from in-point to find tool setup commands + last known
+  // position. Z is sticky in SBP, so we must look back for the cut depth;
+  // X/Y track last known values to cover selections that start with 1D moves.
   var toolSetup = { toolVar: null, toolChange: null, spindleStart: null, moveSpeed: null };
+  var lastZ = null, lastX = null, lastY = null;
   for (var i = inLine - 2; i >= 0; i--) {
     var line = allLines[i].trim();
     var upper = line.toUpperCase();
@@ -494,10 +497,42 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
     if (!toolSetup.toolChange && upper.match(/^C9\b/)) toolSetup.toolChange = allLines[i];
     if (!toolSetup.spindleStart && upper.match(/^C6\b/)) toolSetup.spindleStart = allLines[i];
     if (!toolSetup.moveSpeed && upper.match(/^MS\s*,/)) toolSetup.moveSpeed = allLines[i];
-    if (toolSetup.toolVar && toolSetup.toolChange && toolSetup.spindleStart && toolSetup.moveSpeed) break;
+
+    var mz = upper.match(/^[MJ]Z\s*,\s*([\d.\-]+)/);
+    if (mz && lastZ === null) lastZ = mz[1];
+    var mx = upper.match(/^[MJ]X\s*,\s*([\d.\-]+)/);
+    if (mx && lastX === null) lastX = mx[1];
+    var my = upper.match(/^[MJ]Y\s*,\s*([\d.\-]+)/);
+    if (my && lastY === null) lastY = my[1];
+    var m2 = upper.match(/^[MJ]2\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (m2) {
+      if (lastX === null) lastX = m2[1];
+      if (lastY === null) lastY = m2[2];
+    }
+    var m3 = upper.match(/^[MJ]3\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (m3) {
+      if (lastX === null) lastX = m3[1];
+      if (lastY === null) lastY = m3[2];
+      if (lastZ === null) lastZ = m3[3];
+    }
+    var mo = upper.match(/^MO\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (mo) {
+      if (lastX === null) lastX = mo[1];
+      if (lastY === null) lastY = mo[2];
+      if (lastZ === null) lastZ = mo[3];
+    }
+    var cg = upper.match(/^CG\s*,[^,]*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (cg) {
+      if (lastX === null) lastX = cg[1];
+      if (lastY === null) lastY = cg[2];
+    }
+
+    if (toolSetup.toolVar && toolSetup.toolChange && toolSetup.spindleStart && toolSetup.moveSpeed &&
+        lastX !== null && lastY !== null && lastZ !== null) break;
   }
 
-  // Scan selected lines for the first XY position
+  // Scan selected lines for the first XY position; fall back to backward-scan
+  // lastX/lastY when the selection starts with 1D moves (MX/MY).
   var startX = null, startY = null;
   for (var i = inLine - 1; i < outLine && i < allLines.length; i++) {
     var scanLine = allLines[i].trim().toUpperCase();
@@ -506,6 +541,8 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
     var arcMatch = scanLine.match(/^CG\s*,[^,]*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
     if (arcMatch) { startX = arcMatch[1]; startY = arcMatch[2]; break; }
   }
+  if (startX === null && lastX !== null) startX = lastX;
+  if (startY === null && lastY !== null) startY = lastY;
 
   // Build the output file
   var output = [];
@@ -520,6 +557,11 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
   output.push("JZ," + safeZ);
   if (startX !== null && startY !== null) {
     output.push("J2," + startX + "," + startY);
+  }
+  // Restore sticky Z that was in effect before the in-point (SBP doesn't
+  // repeat Z on subsequent XY moves). Controlled plunge to be safe.
+  if (lastZ !== null) {
+    output.push("MZ," + lastZ);
   }
 
   output.push("' --- Begin cutting ---");

--- a/dashboard/apps/previewer.fma/js/app.js
+++ b/dashboard/apps/previewer.fma/js/app.js
@@ -422,13 +422,17 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
     }
   }
 
-  // Scan backward from in-point to find tool setup commands
+  // Scan backward from in-point to find tool setup commands + last known
+  // position. Z is sticky in SBP (no retract between XY moves once plunged),
+  // so we must look back for the cut depth. We also need fallback X/Y in case
+  // the first selected move is 1D (MX/MY) and doesn't include both axes.
   var toolSetup = {
     toolVar: null,   // &tool = N
     toolChange: null, // C9
     spindleStart: null, // C6
     moveSpeed: null  // MS,xy,z
   };
+  var lastZ = null, lastX = null, lastY = null;
 
   for (var i = inLine - 2; i >= 0; i--) {  // -2 because 1-based, and we want lines before in-point
     var line = allLines[i].trim();
@@ -454,14 +458,54 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
       toolSetup.moveSpeed = allLines[i];
     }
 
-    // Stop scanning once we have all commands
+    // Track last known X, Y, Z from any move command before the in-point.
+    // MZ,z  JZ,z
+    var mz = upper.match(/^[MJ]Z\s*,\s*([\d.\-]+)/);
+    if (mz && lastZ === null) lastZ = mz[1];
+    // MX,x  JX,x
+    var mx = upper.match(/^[MJ]X\s*,\s*([\d.\-]+)/);
+    if (mx && lastX === null) lastX = mx[1];
+    // MY,y  JY,y
+    var my = upper.match(/^[MJ]Y\s*,\s*([\d.\-]+)/);
+    if (my && lastY === null) lastY = my[1];
+    // M2,x,y  J2,x,y  (sets X and Y)
+    var m2 = upper.match(/^[MJ]2\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (m2) {
+      if (lastX === null) lastX = m2[1];
+      if (lastY === null) lastY = m2[2];
+    }
+    // M3,x,y,z  J3,x,y,z  (sets X, Y, Z)
+    var m3 = upper.match(/^[MJ]3\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (m3) {
+      if (lastX === null) lastX = m3[1];
+      if (lastY === null) lastY = m3[2];
+      if (lastZ === null) lastZ = m3[3];
+    }
+    // MO,x,y,z,a,b,c  (multi-axis; first three are X,Y,Z)
+    var mo = upper.match(/^MO\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (mo) {
+      if (lastX === null) lastX = mo[1];
+      if (lastY === null) lastY = mo[2];
+      if (lastZ === null) lastZ = mo[3];
+    }
+    // CG,dir,endX,endY,...  (arc endpoint sets X,Y)
+    var cg = upper.match(/^CG\s*,[^,]*,\s*([\d.\-]+)\s*,\s*([\d.\-]+)/);
+    if (cg) {
+      if (lastX === null) lastX = cg[1];
+      if (lastY === null) lastY = cg[2];
+    }
+
+    // Stop scanning once we have all commands + positions
     if (toolSetup.toolVar && toolSetup.toolChange &&
-        toolSetup.spindleStart && toolSetup.moveSpeed) {
+        toolSetup.spindleStart && toolSetup.moveSpeed &&
+        lastX !== null && lastY !== null && lastZ !== null) {
       break;
     }
   }
 
-  // Scan selected lines for the first XY position (for rapid jog to start)
+  // Scan selected lines for the first XY position (for rapid jog to start).
+  // Falls back to the backward-scan lastX/lastY if the selection starts with
+  // 1D moves (MX/MY) that don't supply both axes.
   var startX = null, startY = null;
   for (var i = inLine - 1; i < outLine && i < allLines.length; i++) {
     var scanLine = allLines[i].trim().toUpperCase();
@@ -479,6 +523,8 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
       break;
     }
   }
+  if (startX === null && lastX !== null) startX = lastX;
+  if (startY === null && lastY !== null) startY = lastY;
 
   // Build the output file
   var output = [];
@@ -494,10 +540,15 @@ function extractSBPSelection(fileContent, inLine, outLine, safeZ) {
   if (toolSetup.toolChange) output.push(toolSetup.toolChange);
   if (toolSetup.spindleStart) output.push(toolSetup.spindleStart);
 
-  // 3. Jog to safe Z, then rapid to starting XY
+  // 3. Jog to safe Z, rapid to starting XY, then controlled plunge to cut Z.
+  // The plunge restores the sticky Z that was in effect just before the
+  // in-point — needed because SBP doesn't repeat Z on subsequent XY moves.
   output.push("JZ," + safeZ);
   if (startX !== null && startY !== null) {
     output.push("J2," + startX + "," + startY);
+  }
+  if (lastZ !== null) {
+    output.push("MZ," + lastZ);
   }
 
   output.push("' --- Begin selected cutting ---");


### PR DESCRIPTION
Z is sticky in SBP — once plunged, subsequent XY moves don't repeat it — so a resumed/sliced selection that starts mid-cut would have no plunge in front of it, leaving the bit at safe Z while cutting commands ran. Backward-scan now also captures the most recent X/Y/Z from any move (MX/MY/MZ/M2/M3/MO/J*/CG) and emits an MZ plunge after the J2 jog.

X/Y backward scan also serves as a fallback when the selection starts with 1D MX or MY moves that don't supply both axes for the J2 jog target.

Applied to both extractSBPSelection copies (previewer + job_manager).