### PR TITLE
Previewer: show native-language line number, rename load message

### DIFF
--- a/dashboard/apps/previewer.fma/js/gui.js
+++ b/dashboard/apps/previewer.fma/js/gui.js
@@ -79,7 +79,7 @@ module.exports = function(callbacks) {
 
 
   self.showLoadingProgress = function(progress) {
-    var msg = 'Processing GCode.  Please wait.' +
+    var msg = 'Processing Toolpath. Please Wait.' +
         '<progress max="100" value="' + (100 * progress) + '"></progress>';
     self.showLoading(msg);
   }

--- a/dashboard/apps/previewer.fma/js/path.js
+++ b/dashboard/apps/previewer.fma/js/path.js
@@ -558,15 +558,12 @@ module.exports = function(scene, callbacks) {
   }
 
 
-  // Displays GCode line plus SBP source line when available, so a mismatch
-  // is visible at a glance during line-mapping debugging. sourceLine is the
-  // 0-based pc (move.sourceLine); we display it 1-based.
+  // Display the line number in the file's native language: SBP source line
+  // if the GCode was simulated from an SBP file (sourceLine is the 0-based
+  // pc, displayed 1-based), otherwise the GCode line as-is.
   function setCurrentLine(gcLine, sourceLine) {
-    var text = infoLine + 'GC ' + gcLine.toLocaleString();
-    if (typeof sourceLine === 'number') {
-      text += '  /  SBP ' + (sourceLine + 1).toLocaleString();
-    }
-    self.codeLine.text(text);
+    var displayed = (typeof sourceLine === 'number') ? (sourceLine + 1) : gcLine;
+    self.codeLine.text(infoLine + displayed.toLocaleString());
   }
   self.setCurrentLine = setCurrentLine;
 

--- a/dashboard/apps/previewer.fma/js/viewer.js
+++ b/dashboard/apps/previewer.fma/js/viewer.js
@@ -1551,11 +1551,10 @@ module.exports = function(container) {
         if (hoveredMove) hoveredMove.setColor(hoveredMove.rapid ? [1,0,0] : [0,1,0]);
         hoveredMove = move;
         move.setColor([1, 1, 1]);  // glow
-        var label = 'GC ' + move.getLine().toLocaleString();
-        if (self.path.hasSourceLines) {
-          label += '  /  SBP ' + (move.sourceLine + 1).toLocaleString();
-        }
-        self.path.codeLine.text(label);
+        var lineNum = self.path.hasSourceLines
+          ? (move.sourceLine + 1)
+          : move.getLine();
+        self.path.codeLine.text(lineNum.toLocaleString());
         canvas.style.cursor = 'pointer';
         self.refresh();
       }


### PR DESCRIPTION
Drop the dual "GC ... / SBP ..." readout in scrub and hover labels. Display only the file's native line: SBP source line for SBP-derived jobs, GCode line for native GCode jobs. The dual display was a debugging aid that's no longer needed now that line-mapping is stable.

Also rename "Processing GCode" loading message to "Processing Toolpath" since the previewer handles both languages.