### PR TITLE
Spindle load meter: read motor rated current, show LOAD bar in sidebar

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -265,6 +265,11 @@
                   AMP value displays the spindle load expressed as current in amps.</span></span><br></div>
                 <div class="dro-addon-value spindle-speed"><span class="sub-label"> RPM </span><input id="sp-speed" type="number" step="25" min="100" max="30000" placeholder="- No VFD/USB -  "></div>
                 <div class="dro-addon-value spindle-power"><span class="sub-label"> AMP </span><span class="no-select-input sp-power">0.00</span></div>
+                <div class="dro-addon-value spindle-load" id="spindle-load-row" style="display:none;">
+                  <span class="sub-label"> LOAD </span>
+                  <span class="sp-load-bar"><span class="sp-load-fill"></span></span>
+                  <span class="no-select-input sp-load-pct">0%</span>
+                </div>
               </div>
 
             </div>    

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -465,6 +465,45 @@ input#override {
     padding-right: 18px;
 }
 
+/* spindle load bar (LOAD row) — match the visual rhythm of the RPM/AMP
+   rows above so the LOAD label lines up with RPM/AMP and the right edge
+   sits where the input/value sits on the other rows. */
+.dro-addon-value.spindle-load {
+    align-items: center;
+    margin-bottom: 5px;
+}
+.dro-addon-value.spindle-load .sp-load-bar {
+    width: 30%;
+    height: 1rem;
+    margin-left: 20px;
+    margin-right: 5px;
+    border: 1px solid gray;
+    background-color: #2a2a2a;
+    overflow: hidden;
+    position: relative;
+}
+.dro-addon-value.spindle-load .sp-load-fill {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background-color: #3aa757;
+    transition: width 0.2s linear, background-color 0.3s ease;
+}
+.dro-addon-value.spindle-load.warn .sp-load-fill {
+    background-color: #e0b020;
+}
+.dro-addon-value.spindle-load.over .sp-load-fill {
+    background-color: #c83030;
+}
+.dro-addon-value.spindle-load .sp-load-pct {
+    width: 3rem;
+    text-align: right;
+    padding-right: 18px;
+    font-size: large;
+    font-weight: bold;
+    color: #ddd;
+}
+
 
 /**       Input / Output Display         ## DEAL WITH varied Input DEFINITIONS in Display **/
 

--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -393,12 +393,31 @@ const { last } = require("underscore");
                     $(".spindle-power .sp-power").css("color", "black");
                 }
                 $(".spindle-power .sp-power").text(formattedDraw);
+
+                // LOAD bar: only shown when the drive reported a usable motor
+                // rated current. Color steps at 70%/90% give an at-a-glance
+                // headroom indicator without users having to read the number.
+                var loadPct = status.spindle.vfdLoadPct;
+                var $loadRow = $(".spindle-load");
+                if (typeof loadPct === "number" && status.spindle.vfdRatedAmps) {
+                    var capped = Math.min(loadPct, 100);
+                    $loadRow.find(".sp-load-fill").css("width", capped + "%");
+                    $loadRow.find(".sp-load-pct").text(Math.round(loadPct) + "%");
+                    $loadRow.removeClass("warn over");
+                    if (loadPct >= 90) $loadRow.addClass("over");
+                    else if (loadPct >= 70) $loadRow.addClass("warn");
+                    $loadRow.show();
+                } else {
+                    $loadRow.hide();
+                }
+
                 $("#dro-addon-3").css("visibility", "visible");
             }
         } else {
             updateSpindleSpeed("- No VFD/USB -  ");
             $(".spindle-speed input").css("color", "gray");
             $(".spindle-power .sp-power").css("color", "gray");
+            $(".spindle-load").hide();
             // hide display when no VFD
             $("#dro-addon-3").css("visibility", "hidden");
         }

--- a/spindle1.js
+++ b/spindle1.js
@@ -22,7 +22,9 @@ function Spin() {
         vfdEnabled: true,
         vfdDesgFreq: 0,
         vfdAchvFreq: 0,
-        vfdAmps: 0
+        vfdAmps: 0,
+        vfdRatedAmps: null,
+        vfdLoadPct: null
     };
     this.vfdSettings = {};
     this.vfdBusy = false;
@@ -92,18 +94,78 @@ Spin.prototype.connectVFD = function() {
 
 let vfdFailures = 0;
 let vfdDisabled = false;
-// Set up 1-second UPDATES to spindleVFD status 
+// One-shot read of the motor rated current from a VFD parameter register
+// (e.g. Delta S1 P07.00 at Modbus 0x0700 = 1792). Used as the denominator
+// for the spindle load percentage.
+//
+// Some drives (e.g. Delta S1) store motor rated current as a percentage of
+// the drive's max output current; when RATED_AS_PCT_OF is set in the config
+// to the drive's max output in Amps, the read value is treated as a percent
+// and the rated current is computed (motor_pct/100 * drive_max). Otherwise
+// the read value is treated as a direct current reading with AMP_MULT.
+//
+// Result is stored in vfdRatedAmps in the same scaling as vfdAmps (raw
+// register units, typically 0.01A) so the load ratio works directly without
+// further unit conversion. Read failures leave vfdRatedAmps null and the UI
+// hides the load bar.
+Spin.prototype.readRatedCurrent = function() {
+    const settings = this.settings.VFD_Settings;
+    const reg = settings.Registers.READ_RATED_CURRENT;
+    if (reg === null || reg === undefined) {
+        log.info("VFD: no READ_RATED_CURRENT register configured; load % disabled");
+        return Promise.resolve(null);
+    }
+    return readVFD(reg, 1)
+        .then((data) => {
+            var raw = data[0];
+            var rated;
+            var pctOf = settings.Registers.RATED_AS_PCT_OF;
+            var scale = settings.Registers.RATED_CURRENT_SCALE;
+            if (pctOf) {
+                // Delta-style: raw is a percentage of drive max output. Convert
+                // to 0.01A units (matches vfdAmps):  raw/100 * pctOf * 100 = raw * pctOf
+                rated = raw * pctOf;
+                log.info(`VFD: motor rated = ${(raw/100*pctOf).toFixed(2)}A (${raw}% of ${pctOf}A drive max, reg ${reg})`);
+            } else if (scale) {
+                // Lenze-style: raw is a direct current reading where raw/scale = Amps.
+                // Convert to 0.01A units to match vfdAmps:  raw * 100 / scale
+                rated = raw * 100 / scale;
+                log.info(`VFD: motor rated = ${(raw/scale).toFixed(2)}A (raw ${raw} ÷ ${scale}, reg ${reg})`);
+            } else {
+                rated = settings.Registers.READ_AMPS_HI === true
+                    ? ((raw >> 8) & 0xFF) * settings.Registers.AMP_MULT
+                    : raw * settings.Registers.AMP_MULT;
+                log.info(`VFD: motor rated current = ${rated} (raw ${raw} from reg ${reg})`);
+            }
+            if (rated > 0) {
+                this.status.vfdRatedAmps = rated;
+            } else {
+                log.warn(`VFD: rated-current read returned ${raw} from reg ${reg}; load % disabled`);
+            }
+            return rated;
+        })
+        .catch((err) => {
+            log.warn(`VFD: rated-current read failed at reg ${reg}: ${err.message}`);
+            return null;
+        });
+};
+
+// Set up 1-second UPDATES to spindleVFD status
 Spin.prototype.startSpindleVFD = function() {
     const settings = this.settings.VFD_Settings;
-    const MAX_VFD_FAILS = 10;  
+    const MAX_VFD_FAILS = 10;
     // Reset the disabled flag when starting
     vfdDisabled = false;
     vfdFailures = 0;
-    
+
     // Store intervalId as instance property so it can be cleared properly
     if (this.vfdInterval) {
         clearInterval(this.vfdInterval);
     }
+
+    // Kick off one-shot rated-current read so load % is available shortly
+    // after connect. Doesn't block the poll loop; just populates vfdRatedAmps.
+    this.readRatedCurrent();
 
     if (this.status.vfdEnabled) {
         this.vfdInterval = setInterval(() => {
@@ -137,7 +199,16 @@ Spin.prototype.startSpindleVFD = function() {
                 var vCur = settings.Registers.READ_AMPS_HI === true ? ((data[ampsOffset] >> 8) & 0xFF) : data[ampsOffset];
                 vCur = vCur * settings.Registers.AMP_MULT;
                 this.status.vfdAmps = vCur;
-                
+
+                // Load % relative to motor rated current (read once at connect).
+                // Capped at 999 so a wildly bad rated value can't blow up the bar.
+                if (this.status.vfdRatedAmps && this.status.vfdRatedAmps > 0) {
+                    var pct = (vCur / this.status.vfdRatedAmps) * 100;
+                    this.status.vfdLoadPct = Math.min(Math.round(pct * 10) / 10, 999);
+                } else {
+                    this.status.vfdLoadPct = null;
+                }
+
                 this.updateStatus(this.status);
                 vfdFailures = 0; // Reset failure count on success
             })
@@ -174,9 +245,11 @@ Spin.prototype.startSpindleVFD = function() {
 // Method to update VFD status Globally via "machine"
 Spin.prototype.updateStatus = function(newStatus) {
     // for the change-check here, probably most efficient to just do this manual comparison
-    if (this.laststatus.vfdDesgFreq !== newStatus.vfdDesgFreq || 
+    if (this.laststatus.vfdDesgFreq !== newStatus.vfdDesgFreq ||
         this.laststatus.vfdAchvFreq !== newStatus.vfdAchvFreq ||
-        this.laststatus.vfdAmps !== newStatus.vfdAmps) {
+        this.laststatus.vfdAmps !== newStatus.vfdAmps ||
+        this.laststatus.vfdLoadPct !== newStatus.vfdLoadPct ||
+        this.laststatus.vfdRatedAmps !== newStatus.vfdRatedAmps) {
         this.status = Object.assign({}, this.status, newStatus);
         this.emit('statusChanged', this.status); // Emit status change to trigger event on machine
         // log.info("VFD Status Changed: " + JSON.stringify(this.status));
@@ -194,6 +267,8 @@ Spin.prototype.disableSpindle = function(reason, isInitialFailure = false) {
     this.status.vfdDesgFreq = -1;
     this.status.vfdAchvFreq = 0;
     this.status.vfdAmps = 0;
+    this.status.vfdLoadPct = null;
+    this.status.vfdRatedAmps = null;
     
     // Clear any running interval
     if (this.vfdInterval) {

--- a/spindles/spindle-VFD-data/spin-DT-1hp-delta.json
+++ b/spindles/spindle-VFD-data/spin-DT-1hp-delta.json
@@ -17,6 +17,8 @@
       "READ_STATUS": 8449,
       "TRIG_READ_FREQ": 8450,
       "SET_FREQUENCY": 8193,
+      "READ_RATED_CURRENT": 1792,
+      "RATED_AS_PCT_OF": 4.2,
       "RPM_MULT": 1,
       "READ_AMPS_HI": null,
       "AMP_MULT": 1,

--- a/spindles/spindle-VFD-data/spin-DT-1hp-lenze.json
+++ b/spindles/spindle-VFD-data/spin-DT-1hp-lenze.json
@@ -16,6 +16,8 @@
       "READ_STATUS": 26,
       "TRIG_READ_FREQ": 24,
       "SET_FREQUENCY": 44,
+      "READ_RATED_CURRENT": 303,
+      "RATED_CURRENT_SCALE": 10,
       "RPM_MULT": 6,
       "READ_AMPS_HI": true,
       "AMP_MULT": 2.6,

--- a/spindles/spindle-VFD-data/spin-PRS5-yaskawaD.json
+++ b/spindles/spindle-VFD-data/spin-PRS5-yaskawaD.json
@@ -19,6 +19,8 @@
       "TRIG_READ_FREQ": 35,
       "SET_FREQUENCY": 640,
       "ENTER_REGISTER": 2320,
+      "READ_RATED_CURRENT": 782,
+      "RATED_CURRENT_SCALE": 100,
       "RPM_MULT": 1,
       "READ_AMPS_HI": false,
       "AMP_MULT": 10,

--- a/spindles/spindle1_settings.json
+++ b/spindles/spindle1_settings.json
@@ -1,31 +1,33 @@
 {
-  "VFD_Settings": {
-    "Name": "spin-DT-1hp-lenze",
-    "COM_PORT": "/dev/vfdACM_controller1",
-    "MB_ADDRESS": 3,
-    "BAUDRATE": 9600,
-    "BYTESIZE": 8,
-    "STOPBITS": 1,
-    "PARITY": "even",
-    "MAX_RPM": 18000,
-    "MIN_RPM": 8000,
-    "Registers": {
-      "READ_FREQUENCY": 24,
-      "READ_ATTAINED_FREQUENCY": 25,
-      "READ_OUTPUT_CURRENT": 26,
-      "READ_STATUS": 26,
-      "TRIG_READ_FREQ": 24,
-      "SET_FREQUENCY": 44,
-      "RPM_MULT": 6,
-      "READ_AMPS_HI": true,
-      "AMP_MULT": 2.6,
-      "UNLOCK_PARAMETERS": 49,
-      "PASSWORD": 0
-    },
-    "Modbus_Function_Codes": {
-      "READ_REGISTER": 3,
-      "WRITE_SINGLE_REGISTER": 6
-    },
-    "READ_LENGTH": 6
-  }
+    "VFD_Settings": {
+        "Name": "spin-DT-1hp-lenze",
+        "COM_PORT": "/dev/ttyACM1",
+        "MB_ADDRESS": 3,
+        "BAUDRATE": 9600,
+        "BYTESIZE": 8,
+        "STOPBITS": 1,
+        "PARITY": "even",
+        "MAX_RPM": 18000,
+        "MIN_RPM": 8000,
+        "Registers": {
+            "READ_FREQUENCY": 24,
+            "READ_ATTAINED_FREQUENCY": 25,
+            "READ_OUTPUT_CURRENT": 26,
+            "READ_STATUS": 26,
+            "TRIG_READ_FREQ": 24,
+            "SET_FREQUENCY": 44,
+            "READ_RATED_CURRENT": 303,
+            "RATED_CURRENT_SCALE": 10,
+            "RPM_MULT": 6,
+            "READ_AMPS_HI": true,
+            "AMP_MULT": 2.6,
+            "UNLOCK_PARAMETERS": 49,
+            "PASSWORD": 0
+        },
+        "Modbus_Function_Codes": {
+            "READ_REGISTER": 3,
+            "WRITE_SINGLE_REGISTER": 6
+        },
+        "READ_LENGTH": 6
+    }
 }


### PR DESCRIPTION
Adds a one-shot read of motor rated current from a VFD parameter at connect time, then computes load % = vfdAmps / vfdRatedAmps in the existing 1s poll. The sidebar gets a new LOAD row beneath AMP - a horizontal bar that fills as current approaches rated, color-stepped at 70%/90% so users get an at-a-glance read on how close they are to maxing out the spindle.

Different drives encode motor rated current differently, so the config now supports two interpretations of the register read:
  - RATED_AS_PCT_OF: <drive_max_A>  (Delta S1: P07-00 is a percentage of the drive's max output current)
  - RATED_CURRENT_SCALE: <n>        (Lenze: P303 is raw/scale Amps;
    Yaskawa V1000: E2-01 is raw/100 Amps)

Per-drive configurations updated:
  - Delta DT 1HP: reg 1792 (P07-00), pct-of 4.2A drive max
  - Lenze ESV:    reg 303  (P303),   scale 10  (0.1A units)
  - Yaskawa V1000: reg 782 (E2-01),  scale 100 (0.01A units)
    (template only; not exercised until a Yaskawa is in hand)

When the rated-current read fails or returns 0, vfdRatedAmps stays null and the LOAD row hides - feature degrades gracefully on drives that don't have the parameter configured.