### PR TITLE
Configuration: add Layout tab for manual control orientation

### DIFF
--- a/config/machine_config.js
+++ b/config/machine_config.js
@@ -58,6 +58,22 @@ MachineConfig.prototype.init = function (machine, callback) {
             if (this._cache && this._cache.manual && !("softlimit_cushion" in this._cache.manual)) {
                 this._cache.manual.softlimit_cushion = 0;
             }
+            // Seed layout-orientation fields so the Configuration > Layout tab
+            // can persist its assignments. util.extend only descends through
+            // existing keys, so without these seeds a client POST silently
+            // drops the new fields and the user's selection won't survive a
+            // page refresh.
+            if (this._cache && this._cache.manual && !("layout_mapping" in this._cache.manual)) {
+                this._cache.manual.layout_mapping = {
+                    "X+": "→",
+                    "X-": "←",
+                    "Y+": "↑",
+                    "Y-": "↓"
+                };
+            }
+            if (this._cache && this._cache.manual && !("layout_origin_corner" in this._cache.manual)) {
+                this._cache.manual.layout_origin_corner = "bl";
+            }
             if (this._cache && !("outputs" in this._cache)) {
                 // Outputs 1, 2, 4 have hardcoded labels and runtime ignores
                 // their policy. The other rows are configurable in the

--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -37,6 +37,8 @@
           </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel8" role="tab" tabindex="0" aria-selected="false" controls="tabpanel8">Outputs</a>
           </li>
+          <li class="tab-title" role="presentational"><a href="#tabpanel9" role="tab" tabindex="0" aria-selected="false" controls="tabpanel9">Layout</a>
+          </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel6" role="tab" tabindex="0" aria-selected="false" controls="tabpanel6">Apps</a>
           </li>
           <li class="tab-title" role="presentational"><a href="#tabpanel7" role="tab" tabindex="0" aria-selected="false" controls="tabpanel7">Users</a>
@@ -1123,6 +1125,177 @@
       <!-- OUTPUTS ----------------------------------------------------------------------------------------------- -->
       <section role="tabpanel" aria-hidden="true" class="content" id="tabpanel8">
         <div id="outputs-list"><!-- fieldsets injected by configuration.js --></div>
+      </section>
+
+
+      <!-- LAYOUT ------------------------------------------------------------------------------------------------ -->
+      <section role="tabpanel" aria-hidden="true" class="content" id="tabpanel9">
+        <div class="row">
+          <fieldset>
+            <legend>Manual Control Orientation</legend>
+            <p style="margin-bottom: 12px;">
+              Pick the corner of the table where machine <strong>0,0</strong> lives, then click each
+              <strong>machine-motion arrow</strong> to assign which keypad direction should produce
+              that motion from where you stand.
+            </p>
+
+            <div class="layout-orientation-container" style="display: flex; gap: 24px; align-items: flex-start;">
+
+              <!-- Overhead view of the machine. Prototype geometry — replace
+                   with your real artwork later; the layout-orientation.js
+                   click handlers key off classnames, not specific coords.
+                   Table is 3:2 horizontal:vertical; gantry is the narrow
+                   vertical bar; spindle sits on the gantry. -->
+              <svg viewBox="0 0 520 360" class="machine-overhead"
+                   style="width: 520px; height: 360px; background: #f4f1ea; border: 1px solid #ccc;">
+
+                <!-- machine table (360 x 240, 3:2 ratio) — MDF tan -->
+                <rect x="80" y="60" width="360" height="240" fill="#d4b585" stroke="#7a5a30" stroke-width="2" rx="4"/>
+
+                <!-- vertical gantry beam (spans table height) — light silver -->
+                <rect x="232" y="66" width="36" height="228" fill="#cfd2d4" stroke="#888" stroke-width="1"/>
+                <line x1="240" y1="66" x2="240" y2="294" stroke="#999" stroke-width="1"/>
+                <line x1="260" y1="66" x2="260" y2="294" stroke="#999" stroke-width="1"/>
+
+                <!-- dark blue end plates at top and bottom of the gantry -->
+                <rect x="222" y="58" width="56" height="14" fill="#1f3a6e" stroke="#0e1d3b" stroke-width="1" rx="2"/>
+                <rect x="222" y="288" width="56" height="14" fill="#1f3a6e" stroke="#0e1d3b" stroke-width="1" rx="2"/>
+
+                <!-- spindle / Z carriage riding on the front (left) of the gantry -->
+                <rect x="182" y="155" width="50" height="50" fill="#4a4a4a" stroke="#222" stroke-width="1.5" rx="2"/>
+                <circle cx="207" cy="180" r="8" fill="#222"/>
+
+                <!-- corner origin radio buttons. The 0,0 label is added
+                     dynamically by layout_orientation.js next to the
+                     currently-selected corner. -->
+                <g class="origin-corners">
+                  <g class="origin-corner" data-corner="tl" style="cursor: pointer;">
+                    <circle cx="92" cy="72" r="9" fill="#fff" stroke="#333" stroke-width="2"/>
+                    <circle class="origin-dot" cx="92" cy="72" r="5" fill="transparent"/>
+                  </g>
+                  <g class="origin-corner" data-corner="tr" style="cursor: pointer;">
+                    <circle cx="428" cy="72" r="9" fill="#fff" stroke="#333" stroke-width="2"/>
+                    <circle class="origin-dot" cx="428" cy="72" r="5" fill="transparent"/>
+                  </g>
+                  <g class="origin-corner" data-corner="bl" style="cursor: pointer;">
+                    <circle cx="92" cy="288" r="9" fill="#fff" stroke="#333" stroke-width="2"/>
+                    <circle class="origin-dot" cx="92" cy="288" r="5" fill="transparent"/>
+                  </g>
+                  <g class="origin-corner" data-corner="br" style="cursor: pointer;">
+                    <circle cx="428" cy="288" r="9" fill="#fff" stroke="#333" stroke-width="2"/>
+                    <circle class="origin-dot" cx="428" cy="288" r="5" fill="transparent"/>
+                  </g>
+                </g>
+
+                <!-- machine-motion arrows around the perimeter, styled as
+                     miniature keypad buttons (rounded rect + white arrow
+                     icon) and colored to match the corresponding axis
+                     color on the keypad mockup. Click to arm; armed state
+                     gets a brighter outline. -->
+                <g class="motion-arrow" data-axis="X+" style="cursor: pointer;">
+                  <rect class="kp-mini" x="462" y="162" width="36" height="36" rx="5"
+                        fill="#0066cc" stroke="#003a6e" stroke-width="1.5"/>
+                  <polygon class="arrow-icon" points="474,170 494,180 474,190" fill="#fff"/>
+                </g>
+
+                <g class="motion-arrow" data-axis="X-" style="cursor: pointer;">
+                  <rect class="kp-mini" x="22" y="162" width="36" height="36" rx="5"
+                        fill="#e67e22" stroke="#7a3d04" stroke-width="1.5"/>
+                  <polygon class="arrow-icon" points="46,170 26,180 46,190" fill="#fff"/>
+                </g>
+
+                <g class="motion-arrow" data-axis="Y+" style="cursor: pointer;">
+                  <rect class="kp-mini" x="242" y="10" width="36" height="36" rx="5"
+                        fill="#27ae60" stroke="#0d5a2c" stroke-width="1.5"/>
+                  <polygon class="arrow-icon" points="260,18 250,38 270,38" fill="#fff"/>
+                </g>
+
+                <g class="motion-arrow" data-axis="Y-" style="cursor: pointer;">
+                  <rect class="kp-mini" x="242" y="314" width="36" height="36" rx="5"
+                        fill="#c0392b" stroke="#621509" stroke-width="1.5"/>
+                  <polygon class="arrow-icon" points="260,346 250,326 270,326" fill="#fff"/>
+                </g>
+
+              </svg>
+
+              <!-- Right side: faithful copy of the actual ShopBot manual
+                   control keypad (same .keypad-button / .keypad-table classes
+                   as the live dashboard keypad). Click a machine-motion arrow
+                   first, then click a keypad button to assign the mapping. -->
+              <div class="layout-keypad-pane" style="display: flex; gap: 20px; align-items: flex-start;">
+
+                <div class="pad-container" style="margin: 0;">
+                  <h5 style="margin: 0 0 8px 0;">Manual Control Keypad</h5>
+
+                  <!-- Yellow ShopBot-style frame around the keypad cluster.
+                       Tightened size + extra padding gives a square outer
+                       footprint with the buttons hugging the center. -->
+                  <div class="layout-yellow-frame" style="
+                       display: inline-block;
+                       background: #f7d447;
+                       border: 2px solid #b89100;
+                       border-radius: 12px;
+                       padding: 16px;
+                       box-shadow: inset 0 0 0 1px rgba(0,0,0,0.15);">
+                    <div class="layout-keypad-mock" style="
+                         display: grid;
+                         grid-template-columns: 64px 64px 64px;
+                         grid-template-rows: 64px 64px 64px;
+                         gap: 6px;
+                         width: 204px;
+                         height: 204px;">
+                      <div></div>
+                      <div class="kp-btn keypad-button drive-button square" data-dir="↑" style="width:64px; height:64px;">
+                        <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
+                      </div>
+                      <div></div>
+                      <div class="kp-btn keypad-button drive-button square" data-dir="←" style="width:64px; height:64px;">
+                        <i class="fa fa-keypad fa-lg fa-arrow-left"></i>
+                      </div>
+                      <div></div>
+                      <div class="kp-btn keypad-button drive-button square" data-dir="→" style="width:64px; height:64px;">
+                        <i class="fa fa-keypad fa-lg fa-arrow-right"></i>
+                      </div>
+                      <div></div>
+                      <div class="kp-btn keypad-button drive-button square" data-dir="↓" style="width:64px; height:64px;">
+                        <i class="fa fa-keypad fa-lg fa-arrow-down"></i>
+                      </div>
+                      <div></div>
+                    </div>
+                  </div>
+
+                  <div class="layout-status" style="margin-top: 12px; font-size: 13px; min-height: 1.5em; max-width: 280px;">
+                    <span class="status-text" style="color: #666;">Click a machine-motion arrow on the left.</span>
+                  </div>
+                </div>
+
+                <!-- Axis labels off to the right of the yellow frame, one row
+                     per keypad direction; row spacing aligns with the
+                     buttons inside the frame. -->
+                <div class="layout-kp-labels" style="padding-top: 42px; font-size: 15px;">
+                  <div class="kp-label-row" data-dir="↑" style="height: 52px; display: flex; align-items: center;">
+                    <span class="kp-arrow" style="font-size: 20px; margin-right: 8px;">↑</span>
+                    <span class="kp-axis" data-dir="↑" style="font-weight: bold; color: #666;">—</span>
+                  </div>
+                  <div class="kp-label-row" data-dir="←" style="height: 52px; display: flex; align-items: center;">
+                    <span class="kp-arrow" style="font-size: 20px; margin-right: 8px;">←</span>
+                    <span class="kp-axis" data-dir="←" style="font-weight: bold; color: #666;">—</span>
+                  </div>
+                  <div class="kp-label-row" data-dir="→" style="height: 52px; display: flex; align-items: center;">
+                    <span class="kp-arrow" style="font-size: 20px; margin-right: 8px;">→</span>
+                    <span class="kp-axis" data-dir="→" style="font-weight: bold; color: #666;">—</span>
+                  </div>
+                  <div class="kp-label-row" data-dir="↓" style="height: 52px; display: flex; align-items: center;">
+                    <span class="kp-arrow" style="font-size: 20px; margin-right: 8px;">↓</span>
+                    <span class="kp-axis" data-dir="↓" style="font-weight: bold; color: #666;">—</span>
+                  </div>
+                </div>
+
+              </div>
+
+            </div>
+          </fieldset>
+        </div>
       </section>
 
 

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -2,6 +2,7 @@ require('./jquery.dragster.js');
 require('jquery');
 var setApps = require('./app_manager.js');
 var setUsers = require('./user_manager');
+require('./layout_orientation.js');
 var Foundation = require('../../../static/js/libs/foundation.min.js');
 var moment = require('../../../static/js/libs/moment.js');
 var Fabmo = require('../../../static/js/libs/fabmo.js');

--- a/dashboard/apps/configuration.fma/js/layout_orientation.js
+++ b/dashboard/apps/configuration.fma/js/layout_orientation.js
@@ -1,0 +1,313 @@
+// Layout tab — manual control orientation. User can either click a
+// machine-motion arrow then a keypad button, OR drag a keypad button
+// onto a machine-motion arrow. Both paths feed the same assignment
+// logic. The assignment treats the user's intent as a coherent rotation
+// around the machine, so picking X+ = ↑ pulls X- to ↓ and rotates the Y
+// axis to fill the freed horizontal slots — matches how operators think
+// about "where I'm standing relative to the machine".
+//
+// Persisted to engine config at machine.manual.layout_mapping. Live
+// dashboard keypad picks up changes via a localStorage ping (storage
+// event listener in main.js).
+(function () {
+  'use strict';
+
+  var DEFAULT_MAPPING = { 'X+': '→', 'X-': '←', 'Y+': '↑', 'Y-': '↓' };
+
+  // Color is tied to the keypad direction (positionally fixed on the
+  // keypad) — the machine arrows take the color of the keypad button
+  // currently mapped to them, so reassigning visibly recolors the
+  // diagram as well.
+  var DIR_COLOR = {
+    '↑': '#27ae60', // green
+    '↓': '#c0392b', // red
+    '←': '#e67e22', // orange
+    '→': '#0066cc'  // blue
+  };
+  var DIR_STROKE = {
+    '↑': '#0d5a2c',
+    '↓': '#621509',
+    '←': '#7a3d04',
+    '→': '#003a6e'
+  };
+
+  // CCW around the compass — used to rotate the whole mapping when the
+  // user picks a new direction for any single axis.
+  var DIR_ORDER = ['→', '↑', '←', '↓'];
+  function rotateDir(dir, q) {
+    var i = DIR_ORDER.indexOf(dir);
+    if (i < 0) return dir;
+    return DIR_ORDER[(i + q + 4) % 4];
+  }
+  function rotationBetween(from, to) {
+    var fromI = DIR_ORDER.indexOf(from);
+    var toI = DIR_ORDER.indexOf(to);
+    if (fromI < 0 || toI < 0) return 0;
+    return (toI - fromI + 4) % 4;
+  }
+
+  var fabmo = null;
+  function getFabmo() {
+    if (fabmo) return fabmo;
+    if (typeof require === 'function') {
+      try {
+        var Fabmo = require('../../../static/js/libs/fabmo.js');
+        fabmo = new Fabmo();
+        return fabmo;
+      } catch (e) { /* fall through */ }
+    }
+    return null;
+  }
+
+  function init() {
+    var $tab = $('#tabpanel9');
+    if (!$tab.length || $tab.data('layout-initialized')) return;
+    $tab.data('layout-initialized', true);
+
+    var mapping = Object.assign({}, DEFAULT_MAPPING);
+    var armed = null;
+    var originCorner = 'bl';
+
+    function dirToAxis(dir) {
+      var found = null;
+      Object.keys(mapping).forEach(function (a) {
+        if (mapping[a] === dir) found = a;
+      });
+      return found;
+    }
+
+    function paintMotionArrow($arrow, isArmed, isDropHover) {
+      var $rect = $arrow.find('.kp-mini');
+      var axis = $arrow.data('axis');
+      var dir = mapping[axis];
+      // Fill follows the keypad direction the axis is mapped to, so it
+      // visibly changes when the user reassigns.
+      $rect.attr('fill', DIR_COLOR[dir]);
+      if (isArmed || isDropHover) {
+        $rect.attr('stroke', '#fff').attr('stroke-width', 3);
+      } else {
+        $rect.attr('stroke', DIR_STROKE[dir]).attr('stroke-width', 1.5);
+      }
+    }
+
+    function paintKeypadButton($btn) {
+      // Keypad button color is fixed by the keypad direction (positional).
+      var dir = $btn.data('dir');
+      $btn.css('background-color', DIR_COLOR[dir]);
+    }
+
+    function paintLabelRow(dir) {
+      var $row = $('.kp-label-row[data-dir="' + dir + '"]');
+      var axis = dirToAxis(dir);
+      var $axisCell = $row.find('.kp-axis');
+      if (axis) {
+        $axisCell.text(axis).css('color', DIR_COLOR[dir]);
+      } else {
+        $axisCell.text('—').css('color', '#999');
+      }
+    }
+
+    function repaintAll() {
+      $tab.find('.motion-arrow').each(function () {
+        var $arr = $(this);
+        paintMotionArrow($arr, armed === $arr.data('axis'), false);
+      });
+      $tab.find('.kp-btn').each(function () {
+        paintKeypadButton($(this));
+      });
+      ['↑', '↓', '←', '→'].forEach(paintLabelRow);
+    }
+
+    function setStatus(text, color) {
+      $tab.find('.status-text').text(text).css('color', color || '#666');
+    }
+
+    function persist() {
+      var f = getFabmo();
+      if (f && f.setConfig) {
+        f.setConfig({
+          machine: {
+            manual: {
+              layout_mapping: mapping,
+              layout_origin_corner: originCorner
+            }
+          }
+        }, function (err) {
+          if (err) {
+            console.warn('Failed to save layout config:', err);
+            setStatus('Saved locally, but engine config write failed.', '#c0392b');
+          }
+        });
+      }
+      try {
+        window.localStorage.setItem('fabmo.layout_mapping', JSON.stringify(mapping));
+      } catch (e) { /* ignore */ }
+    }
+
+    function applyOriginCornerVisual() {
+      $tab.find('.origin-corner').each(function () {
+        var $c = $(this);
+        var isActive = $c.data('corner') === originCorner;
+        $c.find('.origin-dot').attr('fill', isActive ? '#0066cc' : 'transparent');
+      });
+      // Move the "0,0" label to the active corner's group so it follows.
+      var $active = $tab.find('.origin-corner[data-corner="' + originCorner + '"]');
+      $tab.find('.origin-corner text').remove();
+      if ($active.length) {
+        var cx = parseFloat($active.find('circle').attr('cx'));
+        var cy = parseFloat($active.find('circle').attr('cy'));
+        // Position the label inside the table relative to the corner.
+        var dx = (originCorner.indexOf('r') >= 0) ? -32 : 14;
+        var dy = (originCorner.indexOf('b') >= 0) ? -2 : 4;
+        var label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        label.setAttribute('x', cx + dx);
+        label.setAttribute('y', cy + dy);
+        label.setAttribute('font-size', '12');
+        label.setAttribute('font-weight', 'bold');
+        label.setAttribute('fill', '#0066cc');
+        label.textContent = '0,0';
+        $active[0].appendChild(label);
+      }
+    }
+
+    function loadFromEngine() {
+      var f = getFabmo();
+      if (!f || !f.getConfig) return;
+      f.getConfig(function (err, cfg) {
+        if (err || !cfg || !cfg.machine || !cfg.machine.manual) return;
+        var saved = cfg.machine.manual.layout_mapping;
+        if (saved && typeof saved === 'object') {
+          mapping = Object.assign({}, DEFAULT_MAPPING, saved);
+        }
+        var savedCorner = cfg.machine.manual.layout_origin_corner;
+        if (savedCorner && ['tl','tr','bl','br'].indexOf(savedCorner) >= 0) {
+          originCorner = savedCorner;
+        }
+        applyOriginCornerVisual();
+        repaintAll();
+      });
+    }
+
+    // Core assignment: axis A should be triggered by keypad direction D.
+    // Apply as a rotation so the whole mapping stays a coherent
+    // rotation-from-default.
+    function assign(axis, dir) {
+      var q = rotationBetween(mapping[axis], dir);
+      if (q !== 0) {
+        Object.keys(mapping).forEach(function (a) {
+          mapping[a] = rotateDir(mapping[a], q);
+        });
+      }
+      armed = null;
+      setStatus(axis + ' assigned to keypad ' + dir + ' (saved)', '#27ae60');
+      repaintAll();
+      persist();
+    }
+
+    // ---- Click path: arm a motion arrow, then click a keypad button.
+
+    $tab.on('click', '.origin-corner', function () {
+      originCorner = $(this).data('corner');
+      applyOriginCornerVisual();
+      persist();
+    });
+
+    $tab.on('click', '.motion-arrow', function () {
+      var axis = $(this).data('axis');
+      armed = (armed === axis) ? null : axis;
+      if (armed) {
+        setStatus('Armed: ' + armed + ' — now click or drag a keypad button.', DIR_COLOR[mapping[axis]]);
+      } else {
+        setStatus('Click a machine-motion arrow, or drag a keypad button onto one.');
+      }
+      repaintAll();
+    });
+
+    $tab.on('click', '.kp-btn', function () {
+      if (!armed) return; // no-op if no motion is armed — the drag path handles the other order
+      var dir = $(this).data('dir');
+      assign(armed, dir);
+    });
+
+    // ---- Drag path: mousedown on a keypad button, drop on a motion arrow.
+    // Uses pointer events with a small dead-zone so a quick click still
+    // falls through to the click handler above.
+
+    $tab.on('mousedown', '.kp-btn', function (e) {
+      if (e.button !== 0) return;
+      var dir = $(this).data('dir');
+      var startX = e.clientX, startY = e.clientY;
+      var dragging = false;
+      var $ghost = null;
+
+      function makeGhost() {
+        return $('<div></div>').css({
+          position: 'fixed',
+          pointerEvents: 'none',
+          width: '44px',
+          height: '44px',
+          background: '#313366',
+          border: '2px solid #fff',
+          borderRadius: '8px',
+          color: '#fff',
+          fontSize: '22px',
+          fontWeight: 'bold',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          opacity: '0.92',
+          boxShadow: '0 4px 10px rgba(0,0,0,0.35)',
+          zIndex: 9999
+        }).text(dir).appendTo('body');
+      }
+
+      function dropTargetAt(x, y) {
+        var el = document.elementFromPoint(x, y);
+        return $(el).closest('.motion-arrow');
+      }
+
+      function onMove(ev) {
+        if (!dragging) {
+          var dx = ev.clientX - startX, dy = ev.clientY - startY;
+          if (dx * dx + dy * dy < 25) return; // 5px dead-zone
+          dragging = true;
+          $ghost = makeGhost();
+          setStatus('Drop ' + dir + ' on a machine-motion arrow.', '#666');
+        }
+        $ghost.css({ left: (ev.clientX - 22) + 'px', top: (ev.clientY - 22) + 'px' });
+        // Live drop-target highlight
+        $tab.find('.motion-arrow').each(function () {
+          paintMotionArrow($(this), armed === $(this).data('axis'), false);
+        });
+        var $tgt = dropTargetAt(ev.clientX, ev.clientY);
+        if ($tgt.length) paintMotionArrow($tgt, false, true);
+      }
+
+      function onUp(ev) {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        if (!dragging) return; // click path handles it
+        if ($ghost) $ghost.remove();
+        var $tgt = dropTargetAt(ev.clientX, ev.clientY);
+        repaintAll();
+        if ($tgt.length) {
+          assign($tgt.data('axis'), dir);
+        } else {
+          setStatus('Drop cancelled.', '#999');
+        }
+      }
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+
+    repaintAll();
+    loadFromEngine();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -443,7 +443,7 @@
             <div class="pad-container">
               <div class="keypad-table">
                 <div class="keypad-cell">
-                  <div class="x_neg y_pos keypad-button drive-button square">
+                  <div class="x_neg y_pos keypad-button drive-button square" data-keypad-orig="↑←">
                     <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
                   </div>
                   <div class="rot_button a_pos keypad-button drive-button square">
@@ -451,12 +451,12 @@
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div id="keyboardArrow_y_pos" class="y_pos keypad-button drive-button square">
+                  <div id="keyboardArrow_y_pos" class="y_pos keypad-button drive-button square" data-keypad-orig="↑">
                     <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div class="x_pos y_pos keypad-button drive-button square">
+                  <div class="x_pos y_pos keypad-button drive-button square" data-keypad-orig="↑→">
                     <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
                   </div>
                   <div class="rot_button b_pos keypad-button drive-button square">
@@ -464,7 +464,7 @@
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div id="keyboardArrow_x_neg" class="x_neg keypad-button drive-button square">
+                  <div id="keyboardArrow_x_neg" class="x_neg keypad-button drive-button square" data-keypad-orig="←">
                     <i class="fa fa-keypad fa-lg fa-arrow-left"></i>
                   </div>
                 </div>
@@ -478,12 +478,12 @@
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div id="keyboardArrow_x_pos" class="x_pos keypad-button drive-button square">
+                  <div id="keyboardArrow_x_pos" class="x_pos keypad-button drive-button square" data-keypad-orig="→">
                     <i class="fa fa-keypad fa-lg fa-arrow-right"></i>
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div class="x_neg y_neg keypad-button drive-button square">
+                  <div class="x_neg y_neg keypad-button drive-button square" data-keypad-orig="↓←">
                     <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
                   </div>
                   <div class="rot_button a_neg keypad-button drive-button square">
@@ -491,12 +491,12 @@
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div id="keyboardArrow_y_neg" class="y_neg keypad-button drive-button square">
+                  <div id="keyboardArrow_y_neg" class="y_neg keypad-button drive-button square" data-keypad-orig="↓">
                     <i class="fa fa-keypad fa-lg fa-arrow-down"></i>
                   </div>
                 </div>
                 <div class="keypad-cell">
-                  <div class="x_pos y_neg keypad-button drive-button square">
+                  <div class="x_pos y_neg keypad-button drive-button square" data-keypad-orig="↓→">
                     <i class="fa fa-keypad fa-lg fa-arrow-up"></i>
                   </div>
                   <div class="rot_button b_neg keypad-button drive-button square">

--- a/dashboard/static/js/libs/keypad_orientation.js
+++ b/dashboard/static/js/libs/keypad_orientation.js
@@ -1,0 +1,77 @@
+// Applies a user's manual-control orientation mapping to the live keypad
+// DOM by swapping the action classes (x_pos/x_neg/y_pos/y_neg) on each
+// button while leaving the visual icon untouched. This lets a user
+// standing on a non-default side of the machine press the button that
+// LOOKS like "up" and have it move the machine in whatever direction
+// they configured.
+//
+// mapping: object keyed by machine motion (X+, X-, Y+, Y-), valued by the
+//   keypad direction that should produce it (↑, ↓, ←, →). Defaults to the
+//   natural mapping when absent.
+//
+// Each keypad button needs a `data-keypad-orig` attribute identifying the
+// button's apparent direction(s) so we can reapply the mapping regardless
+// of current state.
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.KeypadOrientation = factory();
+})(typeof self !== "undefined" ? self : this, function () {
+  "use strict";
+
+  var DEFAULT_MAPPING = { "X+": "→", "X-": "←", "Y+": "↑", "Y-": "↓" };
+
+  // axis -> class fragment
+  var AXIS_CLASS = {
+    "X+": "x_pos",
+    "X-": "x_neg",
+    "Y+": "y_pos",
+    "Y-": "y_neg"
+  };
+  var ALL_ACTION_CLASSES = ["x_pos", "x_neg", "y_pos", "y_neg"];
+
+  function invertMapping(mapping) {
+    var inv = {};
+    Object.keys(mapping).forEach(function (axis) {
+      inv[mapping[axis]] = axis;
+    });
+    return inv;
+  }
+
+  function applyOrientation(rootEl, mapping) {
+    if (!rootEl) return;
+    mapping = mapping || DEFAULT_MAPPING;
+
+    // Sanity: backfill any missing keys with defaults so we don't silently
+    // produce a button with no action class.
+    var m = Object.assign({}, DEFAULT_MAPPING, mapping);
+    var inv = invertMapping(m);
+
+    var $buttons = $(rootEl).find("[data-keypad-orig]");
+    $buttons.each(function () {
+      var $btn = $(this);
+      // data-keypad-orig can be one of "↑", "↓", "←", "→" for a cardinal
+      // button, or a two-char string like "↑←" for a diagonal.
+      var orig = ($btn.attr("data-keypad-orig") || "").trim();
+      if (!orig) return;
+
+      // Strip any existing action classes — we'll rewrite them.
+      ALL_ACTION_CLASSES.forEach(function (c) { $btn.removeClass(c); });
+
+      // For each apparent direction this button represents, look up the
+      // machine motion it should now produce and add that class.
+      var dirs = orig.split("");
+      dirs.forEach(function (dir) {
+        var axis = inv[dir];
+        if (axis && AXIS_CLASS[axis]) {
+          $btn.addClass(AXIS_CLASS[axis]);
+        }
+      });
+    });
+  }
+
+  return {
+    DEFAULT_MAPPING: DEFAULT_MAPPING,
+    apply: applyOrientation,
+    invert: invertMapping
+  };
+});

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -26,6 +26,7 @@ var FabMoAPI = require("./libs/fabmoapi.js");
 var FabMoUI = require("./libs/fabmoui.js");
 var Keyboard = require("./libs/keyboard.js");
 var Keypad = require("./libs/keypad.js");
+var KeypadOrientation = require("./libs/keypad_orientation.js");
 
 var keypad, keyboard;
 
@@ -1542,6 +1543,20 @@ function setupKeypad() {
     var keypad = new Keypad("#keypad", {
         refreshInterval: manual.refresh_interval || 50,
         pressTime: manual.press_delay != null ? manual.press_delay : 150
+    });
+    // Apply the user's manual-control orientation mapping (set in
+    // Configuration > Layout). Class-swaps the keypad buttons so the
+    // physical layout matches where the operator stands.
+    KeypadOrientation.apply("#keypad", manual.layout_mapping);
+    // Live updates from the Configuration tab arrive via the storage
+    // event — when the Layout tab saves a new mapping, it writes the
+    // JSON to localStorage which fires this listener in other tabs.
+    window.addEventListener("storage", function (ev) {
+        if (ev.key !== "fabmo.layout_mapping") return;
+        try {
+            var newMapping = ev.newValue ? JSON.parse(ev.newValue) : null;
+            KeypadOrientation.apply("#keypad", newMapping);
+        } catch (e) { /* ignore parse errors */ }
     });
     // Make sure the spindle icon is off when entering manual mode
     keypad.on("go", function (move) {


### PR DESCRIPTION
New Layout tab in the configuration app lets the user match the manual control keypad to where they stand relative to the machine. The user picks the corner where machine 0,0 lives, then either clicks a machine-motion arrow followed by a keypad button, or drags a keypad button onto a machine-motion arrow. Either way assigns a coherent rotation of the whole mapping (X+ ↑ implies X- ↓ and rotates Y to fill the freed horizontal slots) so the result always represents a sensible standing position around the machine.

Mapping is persisted to engine config at
machine.manual.layout_mapping; origin corner at
machine.manual.layout_origin_corner. Both keys are seeded in machine_config.js init() so client setConfig posts don't silently drop them (util.extend only descends through existing keys).

The live dashboard keypad picks up changes via a localStorage ping (storage event in main.js). A new keypad_orientation module rewrites the action classes (x_pos/y_neg/etc.) on each button while leaving the visual icons untouched -- diagonal buttons inherit the combined remap automatically because they're tagged with both apparent directions.