### PR TITLE
Configuration: export/import job history; include history DB in snaps…

### DIFF
--- a/dashboard/apps/configuration.fma/index.html
+++ b/dashboard/apps/configuration.fma/index.html
@@ -261,12 +261,21 @@
                 <a id="btn-restore" class="button radius small" style="background-color:rgb(41, 175, 41); margin:0;">Restore saved Profile</a>
               </div>
             </div>
-            <div class="large-12 columns">
+            <div class="large-12 columns" style="margin-bottom: 8px;">
               <div class="row collapse" style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
                 <label style="margin:0; line-height:32px; min-width: 200px;">Save/Restore Macros Only:</label>
                 <a id="btn-macros-backup" class="button radius small" style="background-color:rgb(83, 133, 224); margin:0;">Backup current Macros</a>
                 <input type="file" id="restore_macros_dir" class="hidden" multiple accept=".zip">
                 <a id="btn-macros-restore" class="button radius small" style="background-color:rgb(41, 175, 41); margin:0;">Restore saved Macros</a>
+              </div>
+            </div>
+            <div class="large-12 columns">
+              <div class="row collapse" style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                <label style="margin:0; line-height:32px; min-width: 200px;">Export/Import Job History:</label>
+                <a id="btn-history-export" class="button radius small" style="background-color:rgb(83, 133, 224); margin:0;">Export Job History</a>
+                <input type="file" id="history-import-file" class="hidden" accept=".zip,application/zip">
+                <a id="btn-history-import" class="button radius small" style="background-color:rgb(41, 175, 41); margin:0;">Import Job History</a>
+                <span style="font-size:12px; color:#888;">(includes cut files; may be large)</span>
               </div>
             </div>
           </fieldset>

--- a/dashboard/apps/configuration.fma/js/configuration.js
+++ b/dashboard/apps/configuration.fma/js/configuration.js
@@ -302,7 +302,7 @@ $('#restore_macros_dir').change(function() {
     fabmo.notify('info', 'Uploading and restoring macros...');
     const formData = new FormData();
     formData.append('file', macroFile);
-    
+
     $.ajax({
       url: '/macros/restore',
       type: 'POST',
@@ -316,7 +316,7 @@ $('#restore_macros_dir').change(function() {
       error: function(xhr, status, error) {
         console.error('Upload error:', xhr.responseText);
         let errorMessage = 'Failed to restore macros';
-        
+
         try {
           const errorObj = JSON.parse(xhr.responseText);
           if (errorObj && errorObj.message) {
@@ -334,6 +334,59 @@ $('#restore_macros_dir').change(function() {
       }
     });
   }
+});
+
+// Export Job History (.zip) — streams the server-built archive directly
+// to a download. Payload can be large (cut files included) so we don't
+// fetch().blob() the whole thing through memory if we can avoid it; a
+// simple anchor click hands the response to the browser's downloader.
+$('#btn-history-export').click(function () {
+  fabmo.notify('info', 'Preparing job history archive…');
+  const link = document.createElement('a');
+  link.href = '/history/export';
+  link.download = 'fabmo_history_export.zip';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+});
+
+// Import Job History — upload a .zip produced by export. The server
+// unpacks it back into /opt/fabmo/db/ and /opt/fabmo/files/; restart
+// is required afterwards for the in-memory DB to pick up new state.
+$('#btn-history-import').click(function () {
+  if (!confirm('Importing replaces your current job history and cut files. Continue?')) return;
+  $('#history-import-file').trigger('click');
+});
+
+$('#history-import-file').change(function() {
+  const files = $(this).prop('files');
+  if (files.length !== 1) return;
+  const f = files[0];
+  fabmo.notify('info', 'Uploading job history archive…');
+  const formData = new FormData();
+  formData.append('file', f);
+  $.ajax({
+    url: '/history/import',
+    type: 'POST',
+    data: formData,
+    processData: false,
+    contentType: false,
+    timeout: 600000, // 10-minute timeout for large archives
+    success: function(response) {
+      fabmo.notify('success', (response && response.message) || 'Job history imported. Restart FabMo to load.');
+    },
+    error: function(xhr, status, error) {
+      let msg = 'Failed to import job history';
+      try {
+        const obj = JSON.parse(xhr.responseText);
+        if (obj && obj.message) msg += ': ' + obj.message;
+      } catch (e) { msg += ': ' + error; }
+      fabmo.notify('error', msg);
+    },
+    complete: function() {
+      $('#history-import-file').val('');
+    }
+  });
 });
 
 // Other Config page functions

--- a/routes/config.js
+++ b/routes/config.js
@@ -11,6 +11,7 @@ const fs = require("fs");
 const path = require("path");
 const archiver = require("archiver");
 const extract = require("extract-zip");
+const { spawn } = require("child_process");
 const { runtime } = require("webpack");
 
 const macrosDir = "/opt/fabmo/macros/";
@@ -287,6 +288,156 @@ const backup_macros = function (req, res, next) {
     archive.directory(macrosDir, false);
     archive.finalize();
 };
+
+// Job history export: produce a .zip containing the jobs/files metadata
+// from /opt/fabmo/db/ AND the actual cut files from /opt/fabmo/files/,
+// plus a manifest.json. Uses the system `zip` command so we don't load
+// hundreds of MB into the Node process. The zip is built in /tmp/ and
+// streamed back to the client.
+const FABMO_ROOT = "/opt/fabmo";
+const HISTORY_EXPORT_FILE = path.join(tempDir, "fabmo_history_export.zip");
+
+const export_history = function (req, res, next) {
+    var manifestPath = path.join(tempDir, "fabmo_history_manifest.json");
+    var jobsPath = path.join(FABMO_ROOT, "db/jobs");
+    var filesDir = path.join(FABMO_ROOT, "files");
+
+    // Best-effort counts for the manifest. Treat missing inputs as zero
+    // so an export from a brand-new machine still succeeds.
+    var jobCount = 0, fileCount = 0;
+    try {
+        if (fs.existsSync(jobsPath)) {
+            jobCount = fs
+                .readFileSync(jobsPath, "utf8")
+                .split("\n")
+                .filter(function (l) { return l.trim().length > 0; }).length;
+        }
+    } catch (e) { /* ignore */ }
+    try {
+        if (fs.existsSync(filesDir)) {
+            fileCount = fs.readdirSync(filesDir).length;
+        }
+    } catch (e) { /* ignore */ }
+
+    var machineName = "";
+    try {
+        machineName = (config.engine && config.engine.get && config.engine.get("name")) || "";
+    } catch (e) { /* ignore */ }
+
+    var manifest = {
+        kind: "fabmo_history_export",
+        version: 1,
+        exported_at: new Date().toISOString(),
+        machine_name: machineName,
+        job_count: jobCount,
+        file_count: fileCount
+    };
+
+    try {
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    } catch (e) {
+        log.error("history export: failed to write manifest: " + e.message);
+        res.send(500, { status: "error", message: "Failed to write manifest" });
+        return next();
+    }
+
+    // Stale archive from a prior export — rebuild fresh every time.
+    try { fs.unlinkSync(HISTORY_EXPORT_FILE); } catch (e) { /* ignore */ }
+
+    // zip args: -r recursive, -q quiet, -X strip extra file attrs. Run
+    // from FABMO_ROOT so paths inside the zip are relative (db/, files/).
+    // We include the manifest by copying it into FABMO_ROOT briefly.
+    var manifestInRoot = path.join(FABMO_ROOT, "manifest.json");
+    try {
+        fs.copyFileSync(manifestPath, manifestInRoot);
+    } catch (e) {
+        log.warn("history export: manifest copy failed (continuing): " + e.message);
+    }
+
+    var args = ["-rqX", HISTORY_EXPORT_FILE, "db", "files", "manifest.json"];
+    var proc = spawn("zip", args, { cwd: FABMO_ROOT });
+
+    var stderrBuf = "";
+    proc.stderr.on("data", function (chunk) { stderrBuf += chunk.toString(); });
+
+    proc.on("error", function (err) {
+        try { fs.unlinkSync(manifestInRoot); } catch (e) {}
+        log.error("history export: zip spawn failed: " + err.message);
+        res.send(500, { status: "error", message: "zip command not available" });
+        next();
+    });
+
+    proc.on("close", function (code) {
+        try { fs.unlinkSync(manifestInRoot); } catch (e) {}
+        if (code !== 0) {
+            log.error("history export: zip exited " + code + " stderr=" + stderrBuf);
+            res.send(500, { status: "error", message: "Archive creation failed" });
+            return next();
+        }
+        res.setHeader("Content-Disposition", 'attachment; filename="fabmo_history_export.zip"');
+        res.setHeader("Content-Type", "application/zip");
+        var stream = fs.createReadStream(HISTORY_EXPORT_FILE);
+        stream.pipe(res);
+        stream.on("end", function () {
+            log.info("history export: streamed " + jobCount + " jobs, " + fileCount + " files");
+            next();
+        });
+        stream.on("error", function (err) {
+            log.error("history export: stream failed: " + err.message);
+            next();
+        });
+    });
+};
+
+// Job history import: accept a .zip produced by export_history above and
+// unpack it back into /opt/fabmo/db/ and /opt/fabmo/files/. Same upload
+// pattern as the macros restore — restify drops the file in /tmp/ as
+// upload_xxx and we find the most recent zip there. Caller is expected
+// to restart fabmo afterwards so the in-memory DB picks up the new state.
+function handleHistoryImport(req, res, next) {
+    log.info("History import endpoint hit");
+
+    var recentFiles = findRecentlyModifiedFiles(tempDir);
+    var candidates = recentFiles.filter(function (f) {
+        return f.size > 0 && isZipFile(f.path) && f.name.startsWith("upload_");
+    });
+    if (candidates.length === 0) {
+        log.error("history import: no zip upload found");
+        res.send(400, { status: "error", message: "No valid ZIP file in upload" });
+        return next();
+    }
+    var zipPath = candidates[0].path;
+    log.info("history import: using " + zipPath + " (" + candidates[0].size + " bytes)");
+
+    // unzip -o overwrite, -q quiet, -d target dir
+    var args = ["-oq", zipPath, "-d", FABMO_ROOT];
+    var proc = spawn("unzip", args);
+
+    var stderrBuf = "";
+    proc.stderr.on("data", function (chunk) { stderrBuf += chunk.toString(); });
+
+    proc.on("error", function (err) {
+        log.error("history import: unzip spawn failed: " + err.message);
+        res.send(500, { status: "error", message: "unzip command not available" });
+        next();
+    });
+
+    proc.on("close", function (code) {
+        try { fs.unlinkSync(zipPath); } catch (e) { /* ignore */ }
+        if (code !== 0) {
+            log.error("history import: unzip exited " + code + " stderr=" + stderrBuf);
+            res.send(500, { status: "error", message: "Archive extraction failed" });
+            return next();
+        }
+        log.info("history import: extracted into " + FABMO_ROOT + ". Restart required.");
+        res.send(200, {
+            status: "success",
+            message: "Job history imported. Restart FabMo to load the new history.",
+            restart_required: true
+        });
+        next();
+    });
+}
 
 // Function to check if a file is a ZIP file
 function isZipFile(filePath) {
@@ -957,6 +1108,8 @@ function handleSnapshotUpload(req, res, next) {
 module.exports = function (server) {
     server.post("/macros/restore", handleMacrosRestore);
     server.get("/macros/backup", backup_macros);
+    server.get("/history/export", export_history);
+    server.post("/history/import", handleHistoryImport);
     server.get("/status", get_status);
     server.get("/config", get_config);
     server.post("/config", post_config);

--- a/snapshots.js
+++ b/snapshots.js
@@ -27,6 +27,11 @@ var SNAPSHOT_DIR = "/opt/fabmo_snapshots";
 var DEFAULT_POINTER = "/opt/fabmo_snapshots/.default";
 var LIVE_CONFIG_DIR = "/opt/fabmo/config";
 var LIVE_MACROS_DIR = "/opt/fabmo/macros";
+// Job history metadata (jobs + files tables). Small (<1 MB at the 500
+// entry MAX_HISTORY_LENGTH cap) so we include it in every snapshot.
+// The bulky cut files in /opt/fabmo/files/ are NOT captured — they
+// travel via the separate "Export Job History" archive instead.
+var LIVE_DB_DIR = "/opt/fabmo/db";
 var MAX_AUTO_PER_KIND = 5;
 
 // Snapshots marked as the user-default are mirrored here so they survive
@@ -114,6 +119,25 @@ function _create(name, opts, callback) {
                             return cb(eErr);
                         }
                         fs.copy(LIVE_MACROS_DIR, macrosDest, cb);
+                    });
+                },
+                function (cb) {
+                    // Copy job history metadata (db/) into the snapshot.
+                    // Best-effort: a missing DB shouldn't fail the snapshot.
+                    if (!fs.existsSync(LIVE_DB_DIR)) {
+                        return cb();
+                    }
+                    var dbDest = path.join(dest, "db");
+                    fs.ensureDir(dbDest, function (eErr) {
+                        if (eErr) {
+                            return cb(eErr);
+                        }
+                        fs.copy(LIVE_DB_DIR, dbDest, function (copyErr) {
+                            if (copyErr) {
+                                log.warn("snapshot: db/ copy failed (continuing): " + copyErr.message);
+                            }
+                            cb();
+                        });
                     });
                 },
                 function (cb) {
@@ -553,6 +577,7 @@ function restore(name, callback) {
         }
         var snapConfigDir = path.join(dest, "config");
         var snapMacrosDir = path.join(dest, "macros");
+        var snapDbDir = path.join(dest, "db");
         async.series(
             [
                 function (cb) {
@@ -566,6 +591,15 @@ function restore(name, callback) {
                         return cb();
                     }
                     fs.copy(snapMacrosDir, LIVE_MACROS_DIR, { overwrite: true }, cb);
+                },
+                function (cb) {
+                    // Restore job history metadata if the snapshot has db/.
+                    // Older snapshots (pre-history-in-snapshot) just won't
+                    // have this dir and that's fine.
+                    if (!fs.existsSync(snapDbDir)) {
+                        return cb();
+                    }
+                    fs.copy(snapDbDir, LIVE_DB_DIR, { overwrite: true }, cb);
                 },
             ],
             function (err) {


### PR DESCRIPTION
Two-tier approach for job history backup:

Tier 1 (free) -- snapshots now also capture /opt/fabmo/db/ (jobs + files metadata). Adds <1 MB per snapshot since MAX_HISTORY_LENGTH caps the jobs collection at 500 entries. Restore is best-effort and backwards-compatible: older snapshots without a db/ subdir just skip that step.

Tier 2 (on-demand) -- new Export/Import Job History buttons under "My Custom Profile" produce/consume a .zip that ALSO includes the actual cut files in /opt/fabmo/files/. Large payload (the maxStorage cap is 500 MB) but bounded. Server shells out to system zip/unzip so the node process doesn't have to buffer hundreds of megabytes.

New routes:
  GET  /history/export -- streams the built archive
  POST /history/import -- unpacks an upload into /opt/fabmo/

Import returns restart_required:true; the user-visible toast says to restart so the in-memory DB picks up the new state.

Builds on top of feature/custom-profile-rename for the surrounding UI layout.