### PR TITLE
Editor: hover tooltip showing live variable values

### DIFF
--- a/dashboard/apps/editor.fma/css/style.css
+++ b/dashboard/apps/editor.fma/css/style.css
@@ -108,3 +108,22 @@ h1, h2, h3, h4, h5, h6 {
     color: #ddd;
     background-color:#555;
 }
+
+/* Variable hover tooltip */
+.fabmo-var-hover {
+    position: fixed;
+    z-index: 9999;
+    background: #2b2b2b;
+    color: #eee;
+    border: 1px solid #555;
+    border-radius: 4px;
+    padding: 5px 9px;
+    font-family: Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+    max-width: 400px;
+    word-break: break-all;
+}
+.fabmo-var-hover .hv-val { color: #b5e853; }
+.fabmo-var-hover .hv-undef { color: #999; font-style: italic; }

--- a/dashboard/apps/editor.fma/js/editor.js
+++ b/dashboard/apps/editor.fma/js/editor.js
@@ -254,6 +254,131 @@ require('./cm-fabmo-modes.js');
       }
     }
 
+    // ---- Variable hover tooltip ------------------------------------------------
+    // Looks for OpenSBP variable references (&name, $name, %(expr),
+    // %config.path) at the mouse position and shows the live value via the
+    // /variables/lookup endpoint.
+    var VAR_PATTERNS = [
+      /\$[A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]*\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)*/g,
+      /&[A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]*\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)*/g,
+      /%\([^)]*\)/g,
+      /%[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+/g,
+    ];
+
+    function findVariableAt(lineText, col) {
+      for (var i = 0; i < VAR_PATTERNS.length; i++) {
+        var re = new RegExp(VAR_PATTERNS[i].source, 'g');
+        var m;
+        while ((m = re.exec(lineText)) !== null) {
+          if (col >= m.index && col <= m.index + m[0].length) {
+            return { text: m[0], start: m.index, end: m.index + m[0].length };
+          }
+          if (m.index === re.lastIndex) re.lastIndex++;
+        }
+      }
+      return null;
+    }
+
+    function formatHoverValue(data, requested) {
+      var label = requested;
+      if (!data || data.defined === false) {
+        return label + ' <span class="hv-undef">(not defined)</span>';
+      }
+      var v = data.value;
+      var rendered;
+      if (v === null || v === undefined) {
+        rendered = '<span class="hv-undef">(not defined)</span>';
+      } else if (typeof v === 'number') {
+        rendered = (Math.abs(v) < 1e-9 || Math.abs(v) >= 1e6)
+          ? String(v)
+          : (Math.round(v * 10000) / 10000).toString();
+      } else if (typeof v === 'object') {
+        try { rendered = JSON.stringify(v); } catch (e) { rendered = String(v); }
+      } else {
+        rendered = String(v);
+      }
+      // When the index/property couldn't resolve we fell back to the base
+      // variable on the server — call that out so the user knows what they're
+      // looking at isn't the indexed value.
+      if (data.partial) {
+        var hint = data.partialReason
+          ? '(index unresolved: ' + escapeHtml(data.partialReason) + ')'
+          : '(index unresolved — showing base)';
+        return label + ' = <span class="hv-val">' + escapeHtml(rendered) + '</span>'
+          + ' <span class="hv-undef">' + hint + '</span>';
+      }
+      return label + ' = <span class="hv-val">' + escapeHtml(rendered) + '</span>';
+    }
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function setupVariableHover(cm) {
+      var dwellTimer = null;
+      var tipEl = null;
+      var lastVarText = null;
+      var pending = null; // { varText, x, y }
+
+      function hideTip() {
+        if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null; }
+        if (tipEl && tipEl.parentNode) tipEl.parentNode.removeChild(tipEl);
+        tipEl = null;
+        lastVarText = null;
+        pending = null;
+      }
+
+      function showTip(x, y, html) {
+        if (!tipEl) {
+          tipEl = document.createElement('div');
+          tipEl.className = 'fabmo-var-hover';
+          document.body.appendChild(tipEl);
+        }
+        tipEl.innerHTML = html;
+        // Clamp to viewport
+        var vw = window.innerWidth, vh = window.innerHeight;
+        var w = tipEl.offsetWidth, h = tipEl.offsetHeight;
+        var left = x + 12, top = y + 18;
+        if (left + w > vw - 8) left = vw - w - 8;
+        if (top + h > vh - 8) top = y - h - 8;
+        tipEl.style.left = left + 'px';
+        tipEl.style.top = top + 'px';
+      }
+
+      var wrapper = cm.getWrapperElement();
+      wrapper.addEventListener('mousemove', function (e) {
+        if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null; }
+        var x = e.clientX, y = e.clientY;
+        dwellTimer = setTimeout(function () {
+          var pos = cm.coordsChar({ left: x, top: y });
+          if (pos.outside) { hideTip(); return; }
+          var lineText = cm.getLine(pos.line);
+          if (!lineText) { hideTip(); return; }
+          var found = findVariableAt(lineText, pos.ch);
+          if (!found) { hideTip(); return; }
+          if (found.text === lastVarText && tipEl) return; // already showing
+          lastVarText = found.text;
+          pending = { varText: found.text, x: x, y: y };
+          fabmo.lookupVariable(found.text, function (err, data) {
+            if (!pending || pending.varText !== found.text) return;
+            if (err) { showTip(pending.x, pending.y, escapeHtml(found.text) + ' <span class="hv-undef">(lookup error)</span>'); return; }
+            showTip(pending.x, pending.y, formatHoverValue(data, escapeHtml(found.text)));
+          });
+        }, 350);
+      });
+
+      wrapper.addEventListener('mouseleave', hideTip);
+      cm.on('change', hideTip);
+      cm.on('scroll', hideTip);
+      cm.on('cursorActivity', function () { /* don't hide on cursor move only */ });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') hideTip();
+      });
+    }
+    // ---- end variable hover ---------------------------------------------------
+
     $(document).ready(function() {
       $(document).foundation();
       isDirty = false; // Flag to track if the editor has unsaved changes
@@ -297,6 +422,10 @@ require('./cm-fabmo-modes.js');
             find();
           }
       })
+
+      // Hover-tooltip: when the user dwells over an OpenSBP variable (&x, $y,
+      // %(N), %a.b.c), show its current value in a small popup.
+      setupVariableHover(editor);
 
       // Attach the blur event handler
       editor.on('blur', function(cm) {

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -998,6 +998,22 @@ define(function (require) {
             }.bind(this)
         );
 
+        this._registerHandler(
+            "lookupVariable",
+            function (data, callback) {
+                this.engine.lookupVariable(
+                    data && data.name,
+                    function (err, result) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, result);
+                        }
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
+
         ///
         /// NETWORK MANAGEMENT
         ///

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -1058,6 +1058,10 @@
         this._call("setConfig", data, callback);
     };
 
+    FabMoDashboard.prototype.lookupVariable = function (name, callback) {
+        this._call("lookupVariable", { name: name }, callback);
+    };
+
     FabMoDashboard.prototype.deleteApp = function (id, callback) {
         this._call("deleteApp", id, callback);
     };

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -351,6 +351,18 @@
         });
     };
 
+    // Look up the current value of a single OpenSBP variable (e.g. "$X", "&FOO",
+    // "%(1)", "%machine.envelope.xmax"). Returns { name, type, defined, value }.
+    FabMoAPI.prototype.lookupVariable = function (name, callback) {
+        callback = callback || function () {};
+        this._post(
+            "/variables/lookup",
+            { name: name },
+            function (err) { callback(err || "lookup failed"); },
+            function (err, data) { callback(null, data); }
+        );
+    };
+
     // Version/Info
     FabMoAPI.prototype.getVersion = function (callback) {
         this._get(

--- a/routes/config.js
+++ b/routes/config.js
@@ -76,6 +76,113 @@ var get_config = function (req, res, next) {
 };
 
 /**
+ * @api {post} /variables/lookup Look up the current value of an OpenSBP variable
+ * @apiGroup Config
+ * @apiDescription Resolves a single variable reference (`&name`, `$name`, `%(N)`, or
+ *   `%config.path.to.thing`) against live engine state. Returns the current value,
+ *   or `defined:false` if the variable is not set / not recognized. Used by the
+ *   editor to show hover tooltips with current values.
+ * @apiParam {String} name Variable reference text (e.g. `"$TOOLDIAM"`, `"%(1)"`).
+ */
+var post_variable_lookup = function (req, res, next) {
+    var name = req.params && req.params.name;
+    if (typeof name !== "string" || !name.trim()) {
+        return res.json({ status: "fail", message: "Missing 'name'" });
+    }
+    name = name.trim();
+
+    var parser = require("../runtime/opensbp/sbp_parser");
+    var SBPRuntime = require("../runtime/opensbp").SBPRuntime;
+
+    var ast;
+    try {
+        ast = parser.parse("&__lookup__=" + name);
+    } catch (e) {
+        return res.json({ status: "fail", message: "Parse error: " + e.message });
+    }
+    var expr = ast && ast.expr;
+    if (!expr || typeof expr !== "object" || !expr.type) {
+        return res.json({ status: "fail", message: "Not a variable expression" });
+    }
+
+    // Build a minimal SBPRuntime-shaped object so we can call its read-only
+    // variable lookup methods without booting a full runtime. evaluateSystemVariable
+    // reads from this.driver/this.machine/config, and _getVariableValue reads
+    // straight from config caches.
+    var stub = Object.create(SBPRuntime.prototype);
+    stub.driver = machine.driver;
+    stub.machine = machine;
+    stub.pc = 0;
+    stub.simulation_mode = false;
+    stub.simulated_inputs = {};
+
+    var type = null;
+    var defined = true;
+    var value = null;
+    var partial = false;
+    var partialReason = null;
+
+    function lookupVar(e) {
+        if (e.type === "user_variable" || e.type === "persistent_variable") {
+            return stub._getVariableValue(e);
+        }
+        if (e.type === "system_variable") {
+            return stub.evaluateSystemVariable(e);
+        }
+        throw new Error("Not a variable: " + name);
+    }
+
+    try {
+        if (expr.type === "user_variable") type = "user";
+        else if (expr.type === "persistent_variable") type = "persistent";
+        else if (expr.type === "system_variable") type = "system";
+        else return res.json({ status: "fail", message: "Not a variable: " + name });
+
+        try {
+            value = lookupVar(expr);
+        } catch (firstErr) {
+            // If a $foo[&i] / $foo.bar access path failed (e.g. index variable
+            // not yet defined), fall back to the base variable so the hover
+            // still shows something useful at edit time.
+            if ((expr.type === "user_variable" || expr.type === "persistent_variable")
+                && expr.access && expr.access.length) {
+                try {
+                    var baseExpr = { type: expr.type, name: expr.name, access: [] };
+                    value = lookupVar(baseExpr);
+                    partial = true;
+                    partialReason = firstErr.message;
+                } catch (baseErr) {
+                    defined = false;
+                    value = null;
+                }
+            } else {
+                defined = false;
+                value = null;
+            }
+        }
+        if (value === undefined) {
+            defined = false;
+            value = null;
+        }
+    } catch (e) {
+        defined = false;
+        value = null;
+    }
+
+    res.json({
+        status: "success",
+        data: {
+            name: name,
+            type: type,
+            defined: defined,
+            value: value,
+            partial: partial,
+            partialReason: partialReason,
+        },
+    });
+};
+
+/**
  * @api {post} /config Update engine configuration
  * @apiGroup Config
  * @apiDescription Incorporate the POSTed object into the engine configuration.  Configuration updates take effect immediately.
@@ -1113,6 +1220,7 @@ module.exports = function (server) {
     server.get("/status", get_status);
     server.get("/config", get_config);
     server.post("/config", post_config);
+    server.post("/variables/lookup", post_variable_lookup);
     server.get("/version", get_version);
     server.get("/info", get_info);
     server.get("/profiles", getProfiles);


### PR DESCRIPTION
Dwelling over an OpenSBP variable reference (&x, $y, %(N), %config.path) in the editor pops a small tooltip with the current value, or "(not defined)" if it can't be resolved. For indexed references like $arr[&i] where the index variable isn't set yet, the server falls back to the base variable so users still see something useful at edit time.

Wired through a new POST /variables/lookup route that reuses the runtime's existing _getVariableValue / evaluateSystemVariable against the live machine state, plus matching FabMoAPI / dashboard bridge / fabmo.js methods.