### PR TITLE
Fix: stuck Quit button when wifi connect fails

### DIFF
--- a/dashboard/apps/network_manager.fma/js/network_manager.js
+++ b/dashboard/apps/network_manager.fma/js/network_manager.js
@@ -256,7 +256,13 @@ $(document).ready(function() {
             fabmo.connectToWifi(name, passwd,function(err,data){
                 if(err) {
                     console.log(err);
-                    fabmo.showModal({message:err});
+                    var msg = (err && err.message) ? err.message : (typeof err === 'string' ? err : 'Could not join the network. Check the password and try again.');
+                    fabmo.showModal({
+                        title: 'Could not connect to ' + name,
+                        message: msg,
+                        okText: 'OK',
+                        ok: function() { fabmo.hideModal(); }
+                    });
                 } else {
                     console.log(data);
                     // Remove everything up to and including the first ":" and then trim the result for the variable "address" 

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -1911,7 +1911,12 @@ define(function (require) {
             $(".modalOkay").show();
             $(".modalOkay").text("Quit");
             $(".modalOkay").on("click", function () {
-                options.cancel(); // Use options.cancel() here
+                // Guard the cancel callback — when callers pass only { message }
+                // (e.g. an error popup) there's no cancel handler, and the
+                // unguarded call would throw and leave the modal stuck.
+                if (typeof options.cancel === "function") {
+                    try { options.cancel(); } catch (e) { console.warn("modal cancel handler threw:", e); }
+                }
                 $(".newModal").hide();
                 $(".modalDim").hide();
                 $(".yes-no-buttons").remove(); // Clean up the yes-no buttons if they were used


### PR DESCRIPTION
A wrong-password attempt landed in the error branch which called fabmo.showModal({message: err}) with no cancel handler. Dashboard's showModal auto-appends a "Quit" button when no buttons are configured, but its click handler called options.cancel() unguarded — throwing a TypeError and leaving the modal up. The user had to refresh to recover.

Two changes: guard the fallback Quit click so it always closes the modal, and have the network manager show a proper titled error dialog with an OK button instead of relying on the fallback.