### PR TITLE
Fix: scrollbar flash during dashboard load

### DIFF
--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -13,6 +13,14 @@ body {
     background-color: #eee;
 }
 
+/* Outer dashboard chrome only — prevent a brief scrollbar flash during load.
+   Scoped to body#body (the outer dashboard) so iframe apps (macros, apps grid,
+   etc.) still scroll naturally. */
+html:has(body#body),
+body#body {
+    overflow: hidden;
+}
+
 .noselect {
     -webkit-touch-callout: none;
     -webkit-user-select: none;


### PR DESCRIPTION
The outer dashboard's html and body had no overflow rule, so during the brief window before layout JS clamped iframe heights, transient content overflow surfaced scrollbars on the chrome. Scoped overflow:hidden to body#body (and html:has(body#body)) so the rule only applies in the outer dashboard frame — iframe apps with their own plain <body> keep default scrolling for macros browser, apps grid, etc.