### PR TITLE
Editor: soft-limit pre-check on Run Code Immediately

### DIFF
--- a/dashboard/apps/editor.fma/js/editor.js
+++ b/dashboard/apps/editor.fma/js/editor.js
@@ -28,18 +28,48 @@ require('./cm-fabmo-modes.js');
     let alreadyBlurred = false; // Flag to prevent multiple blur events
 
 
+    // Run code through the soft-limit pre-check, then call `proceed` if the
+    // user accepts (or the code is clean). Mirrors the job-manager warning
+    // pattern — warn-and-confirm, never refuse outright.
+    function runWithBoundsCheck(text, runtime, proceed) {
+      fabmo.checkCodeBounds(text, runtime, function (err, data) {
+        if (err || !data) {
+          // If the check itself fails, don't block the run — log and proceed,
+          // matching prior behavior. G2 still enforces soft limits at firmware.
+          console.warn('bounds pre-check failed:', err);
+          return proceed();
+        }
+        if (!data.exceeds) return proceed();
+        var msg = (data.violations || []).map(function (v) {
+          return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + Number(v.overage).toFixed(2);
+        }).join(', ');
+        fabmo.showModal({
+          title: 'Code exceeds soft limits',
+          message: 'This code would move outside the machine envelope: ' + msg + '.<br>Run anyway?',
+          okText: 'Run anyway',
+          ok: function () { fabmo.hideModal(); proceed(); },
+          cancelText: 'Cancel',
+          cancel: function () { fabmo.hideModal(); }
+        });
+      });
+    }
+
     function execute() {
       $("#execute-menu").hide();
       var text = editor.getValue();
       overrideDirty = false; // only over-ride once
       switch(lang) {
         case "gcode":
-          fabmo.notify('info', 'Executing G-Code program.');
-          fabmo.runGCode(text);
+          runWithBoundsCheck(text, 'gcode', function () {
+            fabmo.notify('info', 'Executing G-Code program.');
+            fabmo.runGCode(text);
+          });
         break;
         case "opensbp":
-          fabmo.notify('info', 'Executing OpenSBP program.');
-          fabmo.runSBP(text);
+          runWithBoundsCheck(text, 'sbp', function () {
+            fabmo.notify('info', 'Executing OpenSBP program.');
+            fabmo.runSBP(text);
+          });
         break;
       }
     }
@@ -52,8 +82,10 @@ require('./cm-fabmo-modes.js');
         fabmo.notify('warn', 'Debug mode (input simulation) is only available for OpenSBP files.');
         return;
       }
-      fabmo.notify('info', 'Executing OpenSBP program in debug mode.');
-      fabmo.runSBPDebug(text);
+      runWithBoundsCheck(text, 'sbp', function () {
+        fabmo.notify('info', 'Executing OpenSBP program in debug mode.');
+        fabmo.runSBPDebug(text);
+      });
     }
 
     function supports_html5_storage() {

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -1014,6 +1014,23 @@ define(function (require) {
             }.bind(this)
         );
 
+        this._registerHandler(
+            "checkCodeBounds",
+            function (data, callback) {
+                this.engine.checkCodeBounds(
+                    data && data.cmd,
+                    data && data.runtime,
+                    function (err, result) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, result);
+                        }
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
+
         ///
         /// NETWORK MANAGEMENT
         ///

--- a/dashboard/static/js/libs/fabmo.js
+++ b/dashboard/static/js/libs/fabmo.js
@@ -1062,6 +1062,10 @@
         this._call("lookupVariable", { name: name }, callback);
     };
 
+    FabMoDashboard.prototype.checkCodeBounds = function (cmd, runtime, callback) {
+        this._call("checkCodeBounds", { cmd: cmd, runtime: runtime }, callback);
+    };
+
     FabMoDashboard.prototype.deleteApp = function (id, callback) {
         this._call("deleteApp", id, callback);
     };

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -564,6 +564,17 @@
         this._post("/code/sim_input", { inp: inp, state: !!state }, callback, callback);
     };
 
+    // Soft-limit pre-check for editor-run code. Returns { exceeds, violations, bounds }.
+    FabMoAPI.prototype.checkCodeBounds = function (cmd, runtime, callback) {
+        callback = callback || function () {};
+        this._post(
+            "/code/check_bounds",
+            { cmd: cmd, runtime: runtime },
+            function (err) { callback(err || "bounds check failed"); },
+            function (err, data) { callback(null, data); }
+        );
+    };
+
     FabMoAPI.prototype.goto = function (move, callback) {
         this.executeRuntimeCode("manual", { cmd: "goto", move: move });
     };

--- a/routes/direct.js
+++ b/routes/direct.js
@@ -1,4 +1,6 @@
 var machine = require("../machine").machine;
+var config = require("../config");
+var bounds = require("../runtime/bounds");
 var log = require("../log").logger("api");
 
 /**
@@ -103,7 +105,54 @@ var simInput = function (req, res, next) {
     res.json({ status: "success", data: { inp: inp, state: state } });
 };
 
+/**
+ * @api {post} /code/check_bounds Soft-limit pre-check for editor-run code
+ * @apiGroup Direct
+ * @apiDescription Compute work-coord extents for the given code and compare
+ *   against the current machine envelope + active G55 offsets. Used by the
+ *   editor so Run Code Immediately gets the same soft-limit warning as a
+ *   submitted job. Does not start motion.
+ * @apiParam {String} runtime "sbp" or "gcode"
+ * @apiParam {String} cmd The code to analyze
+ */
+var checkBounds = function (req, res, next) {
+    var rt = (req.params && req.params.runtime || "").toLowerCase().trim();
+    var cmd = req.params && req.params.cmd;
+    if (typeof cmd !== "string" || !cmd) {
+        return res.json({ status: "error", message: "No code specified in request." });
+    }
+    if (rt !== "sbp" && rt !== "opensbp" && rt !== "g" && rt !== "nc" && rt !== "gcode") {
+        return res.json({ status: "error", message: "Runtime '" + rt + "' is unknown." });
+    }
+    var rtNorm = (rt === "sbp" || rt === "opensbp") ? "sbp" : "gcode";
+
+    bounds.computeStringBounds(cmd, rtNorm, function (err, result) {
+        if (err) {
+            log.warn("/code/check_bounds: " + err.message);
+            return res.json({ status: "error", message: err.message });
+        }
+        var envelope = config.machine.get("envelope");
+        var g55 = {
+            x: config.driver.get("g55x"),
+            y: config.driver.get("g55y"),
+            z: config.driver.get("g55z"),
+        };
+        var check = bounds.checkAgainstEnvelope(result.bounds, envelope, g55);
+        res.json({
+            status: "success",
+            data: {
+                runtime: rtNorm,
+                bounds: result.bounds,
+                exceeds: check.exceeds,
+                violations: check.violations,
+                durationMs: result.durationMs,
+            },
+        });
+    });
+};
+
 module.exports = function (server) {
     server.post("/code", code);
     server.post("/code/sim_input", simInput);
+    server.post("/code/check_bounds", checkBounds);
 };

--- a/runtime/bounds.js
+++ b/runtime/bounds.js
@@ -159,6 +159,31 @@ function computeFileBounds(filePath, callback) {
     });
 }
 
+// Compute bounds for in-memory code (no disk file). Used by the editor-run
+// pre-check so code typed/pasted in the editor gets the same soft-limit
+// scrutiny as submitted jobs. `runtime` is "sbp" or "gcode".
+function computeStringBounds(code, runtime, callback) {
+    var t0 = Date.now();
+    if (typeof code !== "string") return callback(new Error("code must be a string"));
+    var rt = (runtime || "gcode").toLowerCase();
+
+    if (rt === "sbp" || rt === "opensbp") {
+        var SBPRuntime = require("./opensbp/opensbp").SBPRuntime;
+        var sbp = new SBPRuntime();
+        try {
+            sbp.simulateString(code, 0, 0, 0, function (err, gcode) {
+                if (err) return callback(err);
+                callback(null, { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 });
+            });
+        } catch (e) {
+            callback(e);
+        }
+    } else {
+        callback(null, { bounds: scanGCodeBounds(code), durationMs: Date.now() - t0 });
+    }
+}
+
 exports.scanGCodeBounds = scanGCodeBounds;
 exports.checkAgainstEnvelope = checkAgainstEnvelope;
 exports.computeFileBounds = computeFileBounds;
+exports.computeStringBounds = computeStringBounds;


### PR DESCRIPTION
Code typed/pasted into the editor went straight to the runtime with no envelope validation — only submitted jobs got the job-manager's soft-limit badge. So a G53 X0 (or any motion outside the envelope) would quietly hand off to G2, where an alarm could leave the dashboard stuck in "running" with no surfaced error.

Mirror the job-manager pattern for editor-run code: scan the code server-side, compare bounds against the active envelope + g55, and warn with a confirmable modal ("Code exceeds soft limits: X max by 6.00. Run anyway?") before sending to G2. Bounds-check failures don't block — log and proceed, matching the warn-not-refuse semantics already in place for jobs.

Added:
- runtime/bounds.js: computeStringBounds(code, runtime, cb) — parallel to computeFileBounds for in-memory code.
- POST /code/check_bounds — new direct route returning { bounds, exceeds, violations } against current envelope + g55.
- FabMoAPI.checkCodeBounds, dashboard.js handler, fabmo.js bridge.
- editor.js: runWithBoundsCheck wraps execute() and executeDebug().