### PR TITLE
Add Calculator sidebar app

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -189,6 +189,7 @@
             <li><a href="#/app/apps" id="icon_apps" title="Apps"><span>Apps</span></a></li>
             <li><a href="#/app/video" id="icon_video" title="Video"><span>Video</span></a></li>
             <li><a href="#/app/config" id="icon_settings" title="Configuration"><span>Configuration</span></a></li>
+            <li><a href="#" id="icon_calculator" title="Calculator"><span>Calculator</span></a></li>
             <li><a id="icon_sign_out" class="icon_sign_out" title="Sign Out"><span>Sign Out</span></a></li>
             <li><a href="#" id="icon_colapse" title="Expand/Collapse"><span>Collapse</span></a></li>
             <li><p class="expand-text"><small>Expand</small></p></lip>        
@@ -205,6 +206,7 @@
             <li><a href="#/app/apps" id="icon_apps" title="Apps"></a></li>
             <li><a href="#/app/video" id="icon_video" title="Video"></a></li>
             <li><a href="#/app/config" id="icon_settings" title="Configuration"></a></li>
+            <li><a href="#" id="icon_calculator" title="Calculator"></a></li>
             <li><a id="icon_sign_out" class="icon_sign_out" title="Sign Out"></a></li>
           </ul>
         </div>
@@ -641,6 +643,69 @@
         <tr><td class="canned-cut-hud-label">at</td>    <td class="canned-cut-hud-value" id="canned-cut-hud-position">—</td></tr>
       </table>
       <div class="canned-cut-hud-state" id="canned-cut-hud-state">active</div>
+    </div>
+
+    <!-- Calculator modal — sidebar Calculator icon opens this -->
+    <div class="calc-modal-dim" style="display:none;"></div>
+    <div class="calc-modal" style="display:none;" role="dialog" aria-label="Calculator">
+      <div class="calc-header">
+        <span class="calc-title">Calculator</span>
+        <span class="calc-close" title="Close">&times;</span>
+      </div>
+      <div class="calc-body">
+        <label for="calc-expr">Expression</label>
+        <textarea id="calc-expr" rows="2" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="e.g. SQRT(POW(3,2)+POW(4,2)) or $tooldiam * 2 + PI"></textarea>
+        <div class="calc-actions">
+          <select id="calc-helper" title="Insert function or constant at cursor">
+            <option value="">Insert…</option>
+            <optgroup label="Constants">
+              <option value="PI">PI</option>
+            </optgroup>
+            <optgroup label="Basic">
+              <option value="ABS(">ABS(</option>
+              <option value="SQRT(">SQRT(</option>
+              <option value="POW(,)">POW(,)</option>
+              <option value="MIN(,)">MIN(,)</option>
+              <option value="MAX(,)">MAX(,)</option>
+              <option value="MOD(,)">MOD(,)</option>
+              <option value="SIGN(">SIGN(</option>
+            </optgroup>
+            <optgroup label="Rounding">
+              <option value="ROUND(">ROUND(</option>
+              <option value="ROUND(,)">ROUND(,n)</option>
+              <option value="FLOOR(">FLOOR(</option>
+              <option value="CEIL(">CEIL(</option>
+              <option value="TRUNC(">TRUNC(</option>
+            </optgroup>
+            <optgroup label="Trig (degrees)">
+              <option value="SIN(">SIN(</option>
+              <option value="COS(">COS(</option>
+              <option value="TAN(">TAN(</option>
+              <option value="ASIN(">ASIN(</option>
+              <option value="ACOS(">ACOS(</option>
+              <option value="ATAN(">ATAN(</option>
+              <option value="ATAN2(,)">ATAN2(,)</option>
+            </optgroup>
+            <optgroup label="Exp / Log / Random">
+              <option value="EXP(">EXP(</option>
+              <option value="LN(">LN(</option>
+              <option value="LOG10(">LOG10(</option>
+              <option value="RANDOM()">RANDOM()</option>
+            </optgroup>
+            <optgroup label="Operators">
+              <option value=" + ">+ (add)</option>
+              <option value=" - ">- (subtract)</option>
+              <option value=" * ">* (multiply)</option>
+              <option value=" / ">/ (divide)</option>
+              <option value=" MOD ">MOD (modulo)</option>
+            </optgroup>
+          </select>
+          <button id="calc-button" type="button">Calculate</button>
+        </div>
+        <label for="calc-result">Result</label>
+        <input type="text" id="calc-result" readonly>
+        <div class="calc-error" id="calc-error" style="display:none;"></div>
+      </div>
     </div>
 
     <script src="/js/libs/socket.io.js"></script>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -902,6 +902,103 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 #icon_network 		{ background-image: url('../img/icon_network.png');	}
 #icon_sign_out 		{ background-image: url('../img/icon_sign_out.png');	}
 
+/* Calculator sidebar icon — FontAwesome glyph instead of a background PNG.
+   Vertically center the glyph so it aligns with the text label in the
+   expanded sidebar (icons in the wide collapsed bar are also centered
+   inside their cells, so this works in both layouts). */
+#icon_calculator { background-image: none; position: relative; }
+#icon_calculator:before {
+    position: absolute;
+    font-family: 'FontAwesome';
+    font-size: 22px;
+    top: 50%;
+    left: 12px;
+    transform: translateY(-50%);
+    content: "\f1ec"; /* fa-calculator */
+}
+
+/* Calculator modal */
+.calc-modal-dim {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.35);
+    z-index: 3000;
+}
+.calc-modal {
+    position: fixed;
+    top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    width: 420px;
+    max-width: 92vw;
+    background: #fff;
+    border-radius: 6px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+    z-index: 3001;
+    color: #333;
+    font-family: 'source_sans_proregular', sans-serif;
+}
+.calc-modal .calc-header {
+    background: #313366;
+    color: #fff;
+    padding: 8px 14px;
+    border-radius: 6px 6px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.calc-modal .calc-title { font-weight: bold; font-size: 16px; }
+.calc-modal .calc-close {
+    cursor: pointer;
+    font-size: 22px;
+    line-height: 1;
+    padding: 0 6px;
+    user-select: none;
+}
+.calc-modal .calc-close:hover { color: #ffda29; }
+.calc-modal .calc-body { padding: 12px 14px 14px; }
+.calc-modal .calc-body label {
+    display: block;
+    font-size: 12px;
+    font-weight: bold;
+    color: #555;
+    margin-top: 6px;
+    margin-bottom: 4px;
+}
+.calc-modal #calc-expr,
+.calc-modal #calc-result {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 14px;
+    padding: 6px 8px;
+    border: 1px solid #bbb;
+    border-radius: 3px;
+    margin: 0;
+}
+.calc-modal #calc-result { background: #f5f5f5; }
+.calc-modal .calc-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+.calc-modal #calc-helper { flex: 1; padding: 4px 6px; }
+.calc-modal #calc-button {
+    background: #5Daa35;
+    color: #fff;
+    border: none;
+    padding: 4px 18px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-weight: bold;
+}
+.calc-modal #calc-button:hover { background: #4d9128; }
+.calc-modal .calc-error {
+    color: #b00020;
+    font-size: 13px;
+    margin-top: 6px;
+    font-family: Menlo, Consolas, monospace;
+}
+
 .colapsed #icon_colapse { background-image: url('../img/icon_colapse.png');	}
 
 

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -564,6 +564,17 @@
         this._post("/code/sim_input", { inp: inp, state: !!state }, callback, callback);
     };
 
+    // Evaluate a single OpenSBP expression. Returns { expr, value } or an error.
+    FabMoAPI.prototype.evalExpression = function (expr, callback) {
+        callback = callback || function () {};
+        this._post(
+            "/eval",
+            { expr: expr },
+            function (err) { callback(err || "eval failed"); },
+            function (err, data) { callback(null, data); }
+        );
+    };
+
     // Soft-limit pre-check for editor-run code. Returns { exceeds, violations, bounds }.
     FabMoAPI.prototype.checkCodeBounds = function (cmd, runtime, callback) {
         callback = callback || function () {};

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -2435,6 +2435,96 @@ $(".icon_sign_out").on("click", function (e) {
     });
 });
 
+// ========================================================================================= CALCULATOR
+// Lightweight calculator modal driven by the sidebar Calculator icon. Backed
+// by POST /eval, which uses the OpenSBP parser + evaluator — so expressions
+// can include the full math library (SIN, SQRT, ROUND, ...), constants (PI),
+// MOD, and references to live variables ($persistent, &temp, %(N), %config.path).
+(function () {
+    function openCalculator() {
+        $(".calc-modal-dim").show();
+        $(".calc-modal").show();
+        $("#calc-error").hide().text("");
+        // Focus expression input, place caret at end of any existing text
+        var el = document.getElementById("calc-expr");
+        if (el) {
+            el.focus();
+            var v = el.value;
+            el.setSelectionRange(v.length, v.length);
+        }
+    }
+    function closeCalculator() {
+        $(".calc-modal").hide();
+        $(".calc-modal-dim").hide();
+    }
+    function insertAtCursor(textarea, insertion) {
+        var start = textarea.selectionStart, end = textarea.selectionEnd;
+        var v = textarea.value;
+        textarea.value = v.slice(0, start) + insertion + v.slice(end);
+        // Place caret. For things like "POW(,)" / "ATAN2(,)" land between the
+        // parens so the user can start typing the first argument.
+        var landing = start + insertion.length;
+        var m = insertion.match(/\(,/);
+        if (m) landing = start + insertion.indexOf("(") + 1;
+        textarea.focus();
+        textarea.setSelectionRange(landing, landing);
+    }
+    function calculate() {
+        var expr = $("#calc-expr").val();
+        $("#calc-error").hide().text("");
+        if (!expr || !expr.trim()) {
+            $("#calc-result").val("");
+            return;
+        }
+        engine.evalExpression(expr, function (err, data) {
+            if (err || !data) {
+                $("#calc-result").val("");
+                $("#calc-error").text(typeof err === "string" ? err : "Could not evaluate.").show();
+                return;
+            }
+            var v = data.value;
+            var rendered;
+            if (v === null || v === undefined) {
+                rendered = "(undefined)";
+            } else if (typeof v === "number") {
+                rendered = (Math.abs(v) >= 1e6 || (v !== 0 && Math.abs(v) < 1e-4))
+                    ? String(v)
+                    : String(Math.round(v * 1e6) / 1e6);
+            } else if (typeof v === "object") {
+                try { rendered = JSON.stringify(v); } catch (e) { rendered = String(v); }
+            } else {
+                rendered = String(v);
+            }
+            $("#calc-result").val(rendered);
+        });
+    }
+
+    $("#icon_calculator").on("click", function (e) {
+        e.preventDefault();
+        openCalculator();
+    });
+    $(".calc-close").on("click", closeCalculator);
+    $(".calc-modal-dim").on("click", closeCalculator);
+    $("#calc-button").on("click", calculate);
+    $("#calc-expr").on("keydown", function (e) {
+        // Enter (without shift) calculates; Shift+Enter inserts newline.
+        if ((e.key === "Enter" || e.keyCode === 13) && !e.shiftKey) {
+            e.preventDefault();
+            calculate();
+        } else if (e.key === "Escape") {
+            closeCalculator();
+        }
+    });
+    $("#calc-helper").on("change", function () {
+        var v = this.value;
+        if (!v) return;
+        var ta = document.getElementById("calc-expr");
+        insertAtCursor(ta, v);
+        // Reset dropdown so picking the same item twice still fires.
+        this.selectedIndex = 0;
+    });
+})();
+
 // ========================================================================================= KEYPAD DRAGABILITY
 // Keypad Modal Drag Functionality
 function makeKeypadDraggable() {

--- a/routes/direct.js
+++ b/routes/direct.js
@@ -151,8 +151,55 @@ var checkBounds = function (req, res, next) {
     });
 };
 
+/**
+ * @api {post} /eval Evaluate a single OpenSBP expression
+ * @apiGroup Direct
+ * @apiDescription Evaluate an OpenSBP expression and return the resulting value.
+ *   Supports the same math (SIN, COS, SQRT, ROUND, MIN, MAX, MOD, PI, ...),
+ *   variables ($persistent, &temp, %(N), %config.path), and operators that
+ *   work in user code. Powers the dashboard's calculator app.
+ * @apiParam {String} expr The expression text (e.g. "SQRT(POW(3,2)+POW(4,2))")
+ */
+var evalExpr = function (req, res, next) {
+    var expr = req.params && req.params.expr;
+    if (typeof expr !== "string" || !expr.trim()) {
+        return res.json({ status: "fail", message: "Missing 'expr'" });
+    }
+    expr = expr.trim();
+
+    var parser = require("../runtime/opensbp/sbp_parser");
+    var SBPRuntime = require("../runtime/opensbp").SBPRuntime;
+
+    var ast;
+    try {
+        ast = parser.parse("&__eval__=" + expr);
+    } catch (e) {
+        return res.json({ status: "fail", message: "Parse error: " + e.message });
+    }
+    var node = ast && ast.expr;
+    if (node === undefined || node === null) {
+        return res.json({ status: "fail", message: "Empty expression" });
+    }
+
+    var stub = Object.create(SBPRuntime.prototype);
+    stub.driver = machine.driver;
+    stub.machine = machine;
+    stub.pc = 0;
+    stub.simulation_mode = false;
+    stub.simulated_inputs = {};
+
+    var value;
+    try {
+        value = stub._eval(node);
+    } catch (e) {
+        return res.json({ status: "fail", message: e.message });
+    }
+    res.json({ status: "success", data: { expr: expr, value: value } });
+};
+
 module.exports = function (server) {
     server.post("/code", code);
     server.post("/code/sim_input", simInput);
     server.post("/code/check_bounds", checkBounds);
+    server.post("/eval", evalExpr);
 };


### PR DESCRIPTION
A system-default Calculator that opens as a modal overlay on top of whatever app is currently in the main pane — sidebar entry between Configuration and Sign Out, expression field with a function/operator dropdown that inserts at the cursor, result field, and Calculate button. Enter evaluates, Esc closes.

Evaluation runs server-side via a new POST /eval that uses the OpenSBP parser + a stub SBPRuntime, so expressions get the full math library (SIN, COS, SQRT, POW, ROUND, MIN/MAX, MOD, ATAN2, ...), the PI constant, and references to live variables ($persistent, &temp, %(N), and %config.path dot-notation).