### PR TITLE
SBP: simulator line budget so unbounded GOTOs can't hang the engine

### DIFF
--- a/dashboard/apps/editor.fma/js/editor.js
+++ b/dashboard/apps/editor.fma/js/editor.js
@@ -39,6 +39,12 @@ require('./cm-fabmo-modes.js');
           console.warn('bounds pre-check failed:', err);
           return proceed();
         }
+        if (data.partial) {
+          // Simulator hit its line budget — likely an unbounded loop. Bounds
+          // are based on whatever portion ran before the cutoff, so they may
+          // miss later motion. Don't refuse; just log and proceed.
+          console.warn('bounds pre-check truncated (likely loop in source); proceeding without full bounds.');
+        }
         if (!data.exceeds) return proceed();
         var msg = (data.violations || []).map(function (v) {
           return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + Number(v.overage).toFixed(2);

--- a/machine.js
+++ b/machine.js
@@ -1506,7 +1506,12 @@ Machine.prototype.getGCodeForFile = function (filename, callback) {
                     var tx = this.driver.status.posx;
                     var ty = this.driver.status.posy;
                     var tz = this.driver.status.posz;
-                    new SBPRuntime().simulateString(data, tx, ty, tz, callback);
+                    new SBPRuntime().simulateString(data, tx, ty, tz, function (err, gcode, info) {
+                        if (info && info.partial) {
+                            log.warn("Preview simulation truncated for " + filename + " (likely unbounded GOTO/loop); rendering partial result.");
+                        }
+                        callback(err, gcode);
+                    });
                 } else {
                     fs.readFile(filename, callback);
                 }

--- a/routes/direct.js
+++ b/routes/direct.js
@@ -146,6 +146,7 @@ var checkBounds = function (req, res, next) {
                 exceeds: check.exceeds,
                 violations: check.violations,
                 durationMs: result.durationMs,
+                partial: !!result.partial,
             },
         });
     });

--- a/runtime/bounds.js
+++ b/runtime/bounds.js
@@ -146,9 +146,11 @@ function computeFileBounds(filePath, callback) {
             var SBPRuntime = require("./opensbp/opensbp").SBPRuntime;
             var runtime = new SBPRuntime();
             try {
-                runtime.simulateString(data, 0, 0, 0, function (err, gcode) {
+                runtime.simulateString(data, 0, 0, 0, function (err, gcode, info) {
                     if (err) return callback(err);
-                    callback(null, { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 });
+                    var result = { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 };
+                    if (info && info.partial) result.partial = true;
+                    callback(null, result);
                 });
             } catch (e) {
                 callback(e);
@@ -171,9 +173,11 @@ function computeStringBounds(code, runtime, callback) {
         var SBPRuntime = require("./opensbp/opensbp").SBPRuntime;
         var sbp = new SBPRuntime();
         try {
-            sbp.simulateString(code, 0, 0, 0, function (err, gcode) {
+            sbp.simulateString(code, 0, 0, 0, function (err, gcode, info) {
                 if (err) return callback(err);
-                callback(null, { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 });
+                var result = { bounds: scanGCodeBounds(gcode || ""), durationMs: Date.now() - t0 };
+                if (info && info.partial) result.partial = true;
+                callback(null, result);
             });
         } catch (e) {
             callback(e);

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -29,6 +29,16 @@ var config = require("../../config");
 var stream = require("stream");
 var ManualDriver = require("../manual").ManualDriver;
 
+// Maximum program lines a simulation run will expand before bailing out.
+// `simulateString` / `runFile` in non-driver mode loop through GOTO/GOSUB
+// the same way real execution does, with no natural backpressure — an
+// infinite loop in user code (e.g. `START:\nJA,1\nJA,0\nGOTO START`) would
+// otherwise peg the engine. Hitting this budget ends the run cleanly,
+// keeps whatever gcode was produced, and surfaces `info.partial = true`
+// to the simulateString callback so the bounds/previewer paths can warn
+// rather than refuse.
+var MAX_SIM_LINES = 200000;
+
 // Constructor for the OpenSBP runtime
 // The SBPRuntime object is responsible for running OpenSBP code.
 // For more info and command reference: http://www.opensbp.com/
@@ -299,6 +309,11 @@ SBPRuntime.prototype.needsAuth = function (s) {
 SBPRuntime.prototype.runString = function (s) {
     this.currentFilename = "direct input";
     this._endCalled = false; // Reset for new run so errors before _run() aren't suppressed
+    // Sim-mode runaway guard counters. Reset here (not in init()) because
+    // _end() calls init() as part of cleanup, which would otherwise clear
+    // sim_budget_exceeded before simulateString's "end" callback reads it.
+    this.sim_lines_executed = 0;
+    this.sim_budget_exceeded = false;
     //log.info("####=.runString");
     try {
         // Initialize the program
@@ -726,11 +741,17 @@ SBPRuntime.prototype.simulateString = function (s, x, y, z, callback) {
             return callback(new Error("Failed to start simulation: runString returned no stream."));
         }
         var chunks = [];
+        var self = this;
         st.on("data", function (chunk) {
             chunks.push(chunk);
         });
         st.on("end", function () {
-            callback(null, chunks.join(""));
+            // info.partial signals truncated simulation (e.g. infinite loop
+            // hit MAX_SIM_LINES). Callers that care can warn/badge; callers
+            // that don't (legacy 2-arg) silently get the truncated gcode,
+            // which is still strictly better than hanging.
+            var info = { partial: !!self.sim_budget_exceeded };
+            callback(null, chunks.join(""), info);
         });
     } else {
         callback(new Error("Cannot simulate while OpenSBP runtime is busy."));
@@ -1235,6 +1256,24 @@ SBPRuntime.prototype._executeNext = function () {
     if (this.feedhold) {
         log.info("Program is in feedhold.");
         return;
+    }
+
+    // Sim-mode runaway guard. Only enforced when there's no driver attached
+    // (i.e. we're being driven by simulateString / preview / bounds-check, not
+    // executing on real hardware). A program with `GOTO` back to a label would
+    // otherwise loop forever and peg the engine. Once tripped, skip further
+    // counting so we don't re-log on the EOF-handling tail recursions.
+    if (!this.driver && !this.sim_budget_exceeded) {
+        this.sim_lines_executed++;
+        if (this.sim_lines_executed > MAX_SIM_LINES) {
+            log.warn("Simulation budget exhausted at " + MAX_SIM_LINES + " lines — likely infinite loop in source. Truncating.");
+            this.sim_budget_exceeded = true;
+            // Jump past end-of-program so the existing EOF handling in
+            // _executeNext flushes output and calls _end() cleanly. Avoids
+            // having to call _end() reentrantly from here.
+            this.pc = this.program.length;
+            return setImmediate(this._executeNext.bind(this));
+        }
     }
 
     if (this.pc >= this.program.length) {


### PR DESCRIPTION
Editor bounds pre-check, job-manager bounds badge, and the previewer's SBP→gcode renderer all call SBPRuntime.simulateString, which had no cap on expansion. Code like:

    START:
    JA,1
    JA,0
    GOTO START

would loop the simulator forever, peg the engine at 100% CPU, and leave the dashboard hanging on the in-flight request with nothing surfaced.

Add MAX_SIM_LINES (200000) checked in _executeNext when no driver is attached. On exhaustion the run ends cleanly via the existing EOF path and simulateString's callback gains a third `info` arg with `partial: true`. Callers (bounds.js, machine.js, /code/check_bounds, editor.js) forward the flag and log/proceed under the existing warn-not-refuse semantics — truncated bounds are still better than a hang. The counter resets in runString rather than init() because _end() calls init() during cleanup and would otherwise clear the flag before the stream's end event fires.